### PR TITLE
Allowed arbitrary dot number for multiline input

### DIFF
--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -177,7 +177,7 @@
             lines.push("" + indent + "doctest.input(" + (f(expr)) + ");");
           }
           expr = match[1];
-        } else if (match = /^[.](.*)/.exec(comment)) {
+        } else if (match = /^[.]+(.*)/.exec(comment)) {
           expr += "\n" + indent + "  " + match[1];
         } else if (expr) {
           lines.push("" + indent + "doctest.input(" + (f(expr)) + ");");

--- a/src/doctest.coffee
+++ b/src/doctest.coffee
@@ -106,7 +106,7 @@ rewrite = (text, type) ->
       if match = /^>(.*)/.exec comment
         lines.push "#{indent}doctest.input(#{f expr});" if expr
         expr = match[1]
-      else if match = /^[.](.*)/.exec comment
+      else if match = /^[.]+(.*)/.exec comment
         expr += "\n#{indent}  #{match[1]}"
       else if expr
         lines.push "#{indent}doctest.input(#{f expr});"

--- a/test/test.js
+++ b/test/test.js
@@ -60,7 +60,7 @@ global = 'global'
 
   13, 'multiline input'
   // > [1,2,3,
-  // .  4,5,6,
+  // ...  4,5,6,
   // .  7,8,9]
   // [1,2,3,4,5,6,7,8,9]
   14, 'multiline assignment'


### PR DESCRIPTION
I told you ...

So, I discovered that multiline syntax here is different from the one that the `node` shell uses.

Now, it is a powerful work flow to simply paste experiments from the command line, and translate them into doctests, useful for regression, at least! I always did like that using `python -i`, and I see that with node this can be useful combined with `.load` and `.save`.

The problem is that dots from node's prompt can vary with the expression depth, so I simply managed to accept an arbitrary number of dots.
