### PR TITLE
fix browser tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "git://github.com/davidchambers/doctest.git"
   },
   "dependencies": {
-    "escodegen": "~0.0.23",
+    "escodegen": "0.0.28",
     "esprima": "1.0.x",
     "optimist": "0.5.x",
     "underscore": "1.4.x"

--- a/test/server.coffee
+++ b/test/server.coffee
@@ -1,4 +1,5 @@
 fs        = require 'fs'
+https     = require 'https'
 path      = require 'path'
 
 {compile} = require 'coffee-script'
@@ -11,8 +12,20 @@ app = express()
 app.get '/', (req, res) ->
   res.sendfile __dirname + '/test.html'
 
+# escodegen@0.0.23 was the last version to include escodegen.browser.js
+# in the npm package. In order to build this file ourselves we'd need to
+# first install escodegen's devDependencies. It's simpler to request the
+# appropriate version of the file from GitHub and stream the response.
+app.get '/escodegen.browser.js', (req, res) ->
+  version = require('../package.json').dependencies.escodegen
+  url = "https://raw.github.com/Constellation/escodegen/#{version}#{req.url}"
+  https.get url, (res_) ->
+    res.writeHead res_.statusCode,
+      'Content-Length': res_.headers['content-length']
+      'Content-Type': 'application/json; charset=utf-8'
+    res_.pipe res
+
 mappings =
-  escodegen:  'escodegen.browser.js'
   esprima:    'esprima.js'
   underscore: 'underscore.js'
 

--- a/test/test.html
+++ b/test/test.html
@@ -10,8 +10,8 @@
   <script src="/doctest.js"></script>
   <script src="/tests.js"></script>
   <script src="http://code.jquery.com/jquery-latest.js"></script>
-  <script src="http://code.jquery.com/qunit/git/qunit.js"></script>
-  <link rel="stylesheet" href="http://code.jquery.com/qunit/git/qunit.css" />
+  <script src="http://code.jquery.com/qunit/qunit-1.12.0.js"></script>
+  <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.12.0.css" />
   <script src="/browser.js"></script>
 </head>
 <body>


### PR DESCRIPTION
This pull request fixes breakages caused by the following changes:
- escodegen.browser.js is no longer included in the npm package (Constellation/escodegen#119); and
- the URLs for the QUnit files have changed.

We should consider making these dependencies submodules, though we'd be trading fragility for complexity.
