### PR TITLE
replace q with more correct (and more correctly named) repr function

### DIFF
--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -12,7 +12,7 @@
 
 
 (function() {
-  var CoffeeScript, doctest, escodegen, esprima, fetch, q, rewrite, _,
+  var CoffeeScript, doctest, escodegen, esprima, fetch, repr, rewrite, _,
     __slice = [].slice;
 
   doctest = function() {
@@ -66,7 +66,7 @@
         }
       })();
       expected = fn();
-      results.push([_.isEqual(actual, expected), q(expected), q(actual), num]);
+      results.push([_.isEqual(actual, expected), repr(expected), repr(actual), num]);
       input = null;
     }
     return this.complete(results);
@@ -245,22 +245,15 @@
     return lines.join('\n');
   };
 
-  q = function(object) {
-    var error;
-    switch (typeof object) {
-      case 'string':
-        return "\"" + object + "\"";
-      case 'function':
-        try {
-          throw object();
-        } catch (_error) {
-          error = _error;
-          if (error instanceof Error) {
-            return object.name;
-          }
-        }
+  repr = function(val) {
+    switch (Object.prototype.toString.call(val)) {
+      case '[object String]':
+        return '"' + val.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+      case '[object Function]':
+        return val.name;
+      default:
+        return val;
     }
-    return object;
   };
 
 }).call(this);

--- a/src/doctest.coffee
+++ b/src/doctest.coffee
@@ -44,7 +44,12 @@ doctest.run = ->
 
     actual = try input() catch error then error.constructor
     expected = fn()
-    results.push [_.isEqual(actual, expected), q(expected), q(actual), num]
+    results.push [
+      _.isEqual actual, expected
+      repr expected
+      repr actual
+      num
+    ]
     input = null
 
   @complete results
@@ -161,10 +166,18 @@ rewrite.coffee = (input) ->
   lines.join('\n')
 
 
-q = (object) ->
-  switch typeof object
-    when 'string' then return "\"#{object}\""
-    when 'function'
-      try throw object()
-      catch error then return object.name if error instanceof Error
-  object
+# > repr 'foo \\ bar \\ baz'
+# '"foo \\\\ bar \\\\ baz"'
+# > repr 'foo "bar" baz'
+# '"foo \\"bar\\" baz"'
+# > repr TypeError
+# 'TypeError'
+# > repr 42
+# 42
+repr = (val) -> switch Object::toString.call val
+  when '[object String]'
+    '"' + val.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
+  when '[object Function]'
+    val.name
+  else
+    val


### PR DESCRIPTION
`q` was an appropriate name when this function just quoted strings; `repr` better describes the current function.

This pull request fixes the handling of `\` and `"` in string arguments.
