### PR TITLE
simplify rewriters

### DIFF
--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -12,7 +12,7 @@
  */
 
 (function() {
-  var CoffeeScript, commonjsEval, defineFunctionString, doctest, escodegen, esprima, fetch, fs, functionEval, log, noop, pathlib, repr, rewrite, run, validators, _;
+  var CoffeeScript, commonjsEval, defineFunctionString, doctest, escodegen, esprima, fetch, fs, functionEval, log, noop, pathlib, repr, rewrite, run, substring, transformComments, validators, _;
 
   doctest = function(path, options, callback) {
     var type;
@@ -104,97 +104,179 @@
     return rewrite[type](input.replace(/\r\n?/g, '\n'));
   };
 
-  rewrite.js = function(input) {
-    var comment, end, f, idx, line, lines, loc, processComment, start, _i, _len, _ref, _ref1;
-    f = function(expr) {
-      return "function() {\n  return " + expr + "\n}";
-    };
-    processComment = (function(expr) {
-      return function(_arg, start) {
-        var comment, indent, line, lines, match, value, _i, _j, _len, _ref, _ref1;
-        value = _arg.value;
-        lines = [];
-        _ref = value.split('\n');
-        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-          line = _ref[_i];
-          _ref1 = /^([ \t]*)(.*)/.exec(line), _j = _ref1.length - 2, indent = _ref1[_j++], comment = _ref1[_j++];
-          if (match = /^>(.*)/.exec(comment)) {
-            if (expr) {
-              lines.push("__doctest.input(" + (f(expr)) + ")");
-            }
-            expr = match[1];
-          } else if (match = /^[.]+(.*)/.exec(comment)) {
-            expr += "\n" + match[1];
-          } else if (expr) {
-            lines.push("__doctest.input(" + (f(expr)) + ")");
-            lines.push("__doctest.output(" + start.line + ", " + (f(line)) + ")");
-            expr = '';
-          }
+  transformComments = function(comments) {
+    return _.last(_.reduce(comments, function(_arg, _arg1) {
+      var accum, loc, state, value;
+      state = _arg[0], accum = _arg[1];
+      loc = _arg1.loc, value = _arg1.value;
+      return _.reduce(_.initial(value.match(/(?!\s).*/g)), function(_arg2, line) {
+        var accum, prefix, state, _i, _ref;
+        state = _arg2[0], accum = _arg2[1];
+        _ref = /^(>|[.]*)(.*)$/.exec(line), _i = _ref.length - 2, prefix = _ref[_i++], value = _ref[_i++];
+        if (prefix === '>') {
+          return [
+            1, accum.concat({
+              input: {
+                loc: loc,
+                value: value
+              }
+            })
+          ];
+        } else if (state === 0) {
+          return [0, accum];
+        } else if (prefix) {
+          return [
+            1, _.initial(accum).concat({
+              input: {
+                loc: {
+                  start: _.last(accum).input.loc.start,
+                  end: loc.end
+                },
+                value: "" + (_.last(accum).input.value) + "\n" + value
+              }
+            })
+          ];
+        } else {
+          return [
+            0, _.initial(accum).concat({
+              input: _.last(accum).input,
+              output: {
+                loc: loc,
+                value: line
+              }
+            })
+          ];
         }
-        return escodegen.generate(esprima.parse(lines.join('\n')), {
-          indent: '  '
-        });
-      };
-    })('');
-    _ref = esprima.parse(input, {
+      }, [state, accum]);
+    }, [0, []]));
+  };
+
+  substring = function(input, start, end) {
+    var combine;
+    combine = function(a, b) {
+      return ["" + a[0] + b[0], b[1]];
+    };
+    return _.first(_.reduce(input.split(/^/m), function(accum, line, idx) {
+      var isEndLine, isStartLine;
+      isStartLine = idx + 1 === start.line;
+      isEndLine = idx + 1 === end.line;
+      return combine(accum, _.reduce(line, function(_arg, chr, column) {
+        var chrs, inComment;
+        chrs = _arg[0], inComment = _arg[1];
+        if ((isStartLine && column === start.column) || inComment && !(isEndLine && column === end.column)) {
+          return ["" + chrs + chr, true];
+        } else {
+          return ["" + chrs, false];
+        }
+      }, ['', _.last(accum)]));
+    }, ['', false]));
+  };
+
+  rewrite.js = function(input) {
+    var comments, tests, wrap;
+    comments = esprima.parse(input, {
       comment: true,
       loc: true
     }).comments;
-    for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-      loc = _ref[_i].loc;
-      comment = esprima.parse(input, {
-        comment: true,
-        loc: true
-      }).comments[0];
-      _ref1 = comment.loc, start = _ref1.start, end = _ref1.end;
-      lines = input.split('\n');
-      idx = start.line - 1;
-      line = lines[idx];
-      if (end.line === start.line) {
-        lines[idx] = line.substr(0, start.column) + line.substr(end.column);
-      } else {
-        lines[idx] = line.substr(0, start.column);
-        while (++idx !== end.line - 1) {
-          lines[idx] = '';
+    tests = transformComments(comments).concat({
+      input: {
+        value: '',
+        loc: {
+          start: {
+            line: Infinity,
+            column: Infinity
+          }
         }
-        lines[idx] = lines[idx].substr(end.column);
       }
-      line = lines[start.line - 1];
-      lines[start.line - 1] = line.substr(0, start.column) + processComment(comment, loc.start) + line.substr(start.column);
-      input = lines.join('\n');
-    }
-    return input;
+    });
+    wrap = {
+      input: function(test) {
+        return "__doctest.input(function() {\n  return " + test.input.value + ";\n});";
+      },
+      output: function(test) {
+        return "__doctest.output(" + test.output.loc.start.line + ", function() {\n  return " + test.output.value + ";\n});";
+      }
+    };
+    return _.chain(tests).reduce(function(_arg, test) {
+      var chunks, start, _ref;
+      chunks = _arg[0], start = _arg[1];
+      return [chunks.concat(substring(input, start, test.input.loc.start)), ((_ref = test.output) != null ? _ref : test.input).loc.end];
+    }, [
+      [], {
+        line: 1,
+        column: 0
+      }
+    ]).first().zip(_.map(tests, _.compose(escodegen.generate, esprima.parse, function(test) {
+      var p;
+      return ((function() {
+        var _i, _len, _ref, _results;
+        _ref = ['input', 'output'];
+        _results = [];
+        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+          p = _ref[_i];
+          if (p in test) {
+            _results.push(wrap[p](test));
+          }
+        }
+        return _results;
+      })()).join('\n');
+    }))).flatten().value().join('');
   };
 
   rewrite.coffee = function(input) {
-    var comment, expr, f, idx, indent, line, lines, match, _i, _j, _len, _ref;
-    f = function(indent, expr) {
-      return "->\n" + indent + "  " + expr + "\n" + indent;
+    var source, wrap;
+    wrap = {
+      input: function(test) {
+        return "__doctest.input -> " + test.input.value;
+      },
+      output: function(test) {
+        return "__doctest.output " + test.output.loc.start.line + ", -> " + test.output.value;
+      }
     };
-    lines = [];
-    expr = '';
-    _ref = input.split('\n');
-    for (idx = _i = 0, _len = _ref.length; _i < _len; idx = ++_i) {
-      line = _ref[idx];
-      if (match = /^([ \t]*)#(?!##)[ \t]*(.+)/.exec(line)) {
-        _j = match.length - 2, indent = match[_j++], comment = match[_j++];
-        if (match = /^>(.*)/.exec(comment)) {
-          if (expr) {
-            lines.push("" + indent + "__doctest.input " + (f(indent, expr)));
-          }
-          expr = match[1];
-        } else if (match = /^[.]+(.*)/.exec(comment)) {
-          expr += "\n" + indent + "  " + match[1];
+    source = _.chain(input.split('\n')).reduce(function(_arg, line, idx) {
+      var expr, indent, lines, match, prefix, value, _i;
+      expr = _arg[0], lines = _arg[1];
+      if (match = /^([ \t]*)#(?!##)[ \t]*(>|[.]*)(.*)$/.exec(line)) {
+        _i = match.length - 3, indent = match[_i++], prefix = match[_i++], value = match[_i++];
+        if (prefix === '>' && expr) {
+          return [
+            value, lines.concat("" + indent + (wrap.input({
+              input: {
+                value: expr
+              }
+            })))
+          ];
+        } else if (prefix === '>') {
+          return [value, lines];
+        } else if (prefix) {
+          return ["" + expr + "\n" + indent + "  " + value, lines];
         } else if (expr) {
-          lines.push("" + indent + "__doctest.input " + (f(indent, expr)));
-          lines.push("" + indent + "__doctest.output " + (idx + 1) + ", " + (f(indent, comment)));
-          expr = '';
+          return [
+            '', lines.concat([
+              "" + indent + (wrap.input({
+                input: {
+                  value: expr
+                }
+              })), "" + indent + (wrap.output({
+                output: {
+                  value: value,
+                  loc: {
+                    start: {
+                      line: idx + 1
+                    }
+                  }
+                }
+              }))
+            ])
+          ];
+        } else {
+          return [expr, lines];
         }
       } else {
-        lines.push(line);
+        return [expr, lines.concat(line)];
       }
-    }
-    return CoffeeScript.compile(lines.join('\n'));
+    }, ['', []]).last().value().join('\n');
+    return CoffeeScript.compile(source);
   };
 
   defineFunctionString = 'function define() {\n  var arg, idx;\n  for (idx = 0; idx < arguments.length; idx += 1) {\n    arg = arguments[idx];\n    if (typeof arg === \'function\') {\n      arg();\n      break;\n    }\n  }\n}';


### PR DESCRIPTION
Commit message:

> The current JavaScript rewriter is particularly convoluted. It invokes esprima.parse once up front to ascertain the position of each comment, then rewrites the comments one at a time, resulting in the entire file being parsed N + 1 times (where N is the number of comments).
> 
> In addition to being inefficient, this code is confusing: it relies on evaluating `esprima.parse(input)` multiple times with differing results (due to reassignment within the loop). Worst of all, processComment is a stateful function: its return value is determined in part by previously supplied arguments.
> 
> The new rewriters eschew mutation, reassignment, and stateful functions, and are easier to reason about as result. They introduce an intermediate data structure, a list of {input,output} pairs, which breaks the problem into two simpler problems. The JavaScript rewriter invokes esprima.parse once per file rather than N + 1 times.

I'd appreciate your feedback on this, @danse. :)
