### PR TITLE
extract doctests from JavaScript block comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ test: \
 
 test/public/bundle.js: \
 		bower_components/coffee-script/extras/coffee-script.js \
-		bower_components/escodegen/escodegen.browser.js \
 		bower_components/esprima/esprima.js \
 		bower_components/jquery/dist/jquery.js \
 		bower_components/qunit/qunit/qunit.js \

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ function toFahrenheit(degreesCelsius) {
 
 2.  Add script tags:
 
-        <script src="path/to/bower_components/escodegen/escodegen.browser.js"></script>
         <script src="path/to/bower_components/esprima/esprima.js"></script>
         <script src="path/to/bower_components/jquery/dist/jquery.js"></script>
         <script src="path/to/bower_components/underscore/underscore.js"></script>

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,6 @@
   ],
   "dependencies": {
     "coffee-script": "1.7.x",
-    "escodegen": "1.2.x",
     "esprima": "1.0.x",
     "jquery": "2.1.x",
     "underscore": "1.6.x"

--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -12,7 +12,8 @@
  */
 
 (function() {
-  var CoffeeScript, commonjsEval, defineFunctionString, doctest, escodegen, esprima, fetch, fs, functionEval, log, noop, pathlib, repr, rewrite, run, substring, transformComments, validators, _;
+  var CoffeeScript, commonjsEval, defineFunctionString, doctest, esprima, fetch, fs, functionEval, log, noop, pathlib, repr, rewrite, run, substring, transformComments, validators, _,
+    __slice = [].slice;
 
   doctest = function(path, options, callback) {
     var type;
@@ -59,14 +60,13 @@
   doctest.version = '0.6.1';
 
   if (typeof window !== 'undefined') {
-    _ = window._, CoffeeScript = window.CoffeeScript, escodegen = window.escodegen, esprima = window.esprima;
+    _ = window._, CoffeeScript = window.CoffeeScript, esprima = window.esprima;
     window.doctest = doctest;
   } else {
     fs = require('fs');
     pathlib = require('path');
     _ = require('underscore');
     CoffeeScript = require('coffee-script');
-    escodegen = require('escodegen');
     esprima = require('esprima');
     module.exports = doctest;
   }
@@ -105,19 +105,33 @@
   };
 
   transformComments = function(comments) {
-    return _.last(_.reduce(comments, function(_arg, _arg1) {
-      var accum, loc, state, value;
+    return _.last(_.reduce(comments, function(_arg, comment, commentIndex) {
+      var accum, state;
       state = _arg[0], accum = _arg[1];
-      loc = _arg1.loc, value = _arg1.value;
-      return _.reduce(_.initial(value.match(/(?!\s).*/g)), function(_arg2, line) {
-        var accum, prefix, state, _i, _ref;
-        state = _arg2[0], accum = _arg2[1];
-        _ref = /^(>|[.]*)(.*)$/.exec(line), _i = _ref.length - 2, prefix = _ref[_i++], value = _ref[_i++];
+      return _.reduce(comment.value.split('\n'), function(_arg1, line, idx) {
+        var accum, end, normalizedLine, prefix, start, state, value, _i, _ref, _ref1;
+        state = _arg1[0], accum = _arg1[1];
+        switch (comment.type) {
+          case 'Block':
+            normalizedLine = line.replace(/^\s*[*]?\s*/, '');
+            start = end = {
+              line: comment.loc.start.line + idx
+            };
+            break;
+          case 'Line':
+            normalizedLine = line.replace(/^\s*/, '');
+            _ref = comment.loc, start = _ref.start, end = _ref.end;
+        }
+        _ref1 = /^(>|[.]*)(.*)$/.exec(normalizedLine), _i = _ref1.length - 2, prefix = _ref1[_i++], value = _ref1[_i++];
         if (prefix === '>') {
           return [
             1, accum.concat({
+              commentIndex: commentIndex,
               input: {
-                loc: loc,
+                loc: {
+                  start: start,
+                  end: end
+                },
                 value: value
               }
             })
@@ -127,10 +141,11 @@
         } else if (prefix) {
           return [
             1, _.initial(accum).concat({
+              commentIndex: commentIndex,
               input: {
                 loc: {
                   start: _.last(accum).input.loc.start,
-                  end: loc.end
+                  end: end
                 },
                 value: "" + (_.last(accum).input.value) + "\n" + value
               }
@@ -139,10 +154,14 @@
         } else {
           return [
             0, _.initial(accum).concat({
+              commentIndex: commentIndex,
               input: _.last(accum).input,
               output: {
-                loc: loc,
-                value: line
+                loc: {
+                  start: start,
+                  end: end
+                },
+                value: value
               }
             })
           ];
@@ -173,54 +192,63 @@
   };
 
   rewrite.js = function(input) {
-    var comments, tests, wrap;
-    comments = esprima.parse(input, {
-      comment: true,
-      loc: true
-    }).comments;
-    tests = transformComments(comments).concat({
-      input: {
-        value: '',
-        loc: {
-          start: {
-            line: Infinity,
-            column: Infinity
-          }
+    var blockTests, bookend, getComments, lineTests, source, wrap, _ref;
+    wrap = function(test) {
+      return _.chain(['input', 'output']).filter(_.partial(_.has, test)).map(function(type) {
+        return wrap[type](test);
+      }).value().join('\n');
+    };
+    wrap.input = function(test) {
+      return "__doctest.input(function() {\n  return " + test.input.value + ";\n});";
+    };
+    wrap.output = function(test) {
+      return "__doctest.output(" + test.output.loc.start.line + ", function() {\n  return " + test.output.value + ";\n});";
+    };
+    bookend = {
+      value: '',
+      loc: {
+        start: {
+          line: Infinity,
+          column: Infinity
         }
       }
-    });
-    wrap = {
-      input: function(test) {
-        return "__doctest.input(function() {\n  return " + test.input.value + ";\n});";
-      },
-      output: function(test) {
-        return "__doctest.output(" + test.output.loc.start.line + ", function() {\n  return " + test.output.value + ";\n});";
-      }
     };
-    return _.chain(tests).reduce(function(_arg, test) {
-      var chunks, start, _ref;
+    getComments = function(s) {
+      return esprima.parse(s, {
+        comment: true,
+        loc: true
+      }).comments;
+    };
+    _ref = _.chain(getComments(input)).partition(function(c) {
+      return c.type === 'Block';
+    }).map(transformComments).value(), blockTests = _ref[0], lineTests = _ref[1];
+    source = _.chain(lineTests).concat({
+      input: bookend
+    }).reduce(function(_arg, test) {
+      var chunks, start, _ref1;
       chunks = _arg[0], start = _arg[1];
-      return [chunks.concat(substring(input, start, test.input.loc.start)), ((_ref = test.output) != null ? _ref : test.input).loc.end];
+      return [__slice.call(chunks).concat([substring(input, start, test.input.loc.start)]), ((_ref1 = test.output) != null ? _ref1 : test.input).loc.end];
     }, [
       [], {
         line: 1,
         column: 0
       }
-    ]).first().zip(_.map(tests, _.compose(escodegen.generate, esprima.parse, function(test) {
-      var p;
-      return ((function() {
-        var _i, _len, _ref, _results;
-        _ref = ['input', 'output'];
-        _results = [];
-        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-          p = _ref[_i];
-          if (p in test) {
-            _results.push(wrap[p](test));
-          }
-        }
-        return _results;
-      })()).join('\n');
-    }))).flatten().value().join('');
+    ]).first().zip(_.map(lineTests, wrap)).flatten().value().join('');
+    return _.chain(getComments(source)).filter(function(c) {
+      return c.type === 'Block';
+    }).concat(bookend).reduce(function(_arg, comment, idx) {
+      var chunks, s, start;
+      chunks = _arg[0], start = _arg[1];
+      s = _.chain(blockTests).filter(function(t) {
+        return t.commentIndex === idx;
+      }).map(wrap).value().join('\n');
+      return [__slice.call(chunks).concat([substring(source, start, comment.loc.start)], [s]), comment.loc.end];
+    }, [
+      [], {
+        line: 1,
+        column: 0
+      }
+    ]).first().value().join('');
   };
 
   rewrite.coffee = function(input) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "coffee-script": "1.7.x",
     "commander": "2.1.x",
-    "escodegen": "1.2.x",
     "esprima": "1.0.x",
     "underscore": "1.6.x"
   },

--- a/src/doctest.coffee
+++ b/src/doctest.coffee
@@ -38,14 +38,13 @@ doctest.version = '0.6.1'
 
 
 if typeof window isnt 'undefined'
-  {_, CoffeeScript, escodegen, esprima} = window
+  {_, CoffeeScript, esprima} = window
   window.doctest = doctest
 else
   fs = require 'fs'
   pathlib = require 'path'
   _ = require 'underscore'
   CoffeeScript = require 'coffee-script'
-  escodegen = require 'escodegen'
   esprima = require 'esprima'
   module.exports = doctest
 
@@ -87,25 +86,38 @@ rewrite = (input, type) ->
 # .   value: ' 42'
 # .   loc: start: {line: 2, column: 0}, end: {line: 2, column: 5}
 # . ]
-# [{input: {value: ' 6 * 7', loc: {start: {line: 1, column: 0}, end: {line: 1, column: 10}}}, output: {value: '42', loc: {start: {line: 2, column: 0}, end: {line: 2, column: 5}}}}]
+# [{commentIndex: 1, input: {value: ' 6 * 7', loc: {start: {line: 1, column: 0}, end: {line: 1, column: 10}}}, output: {value: '42', loc: {start: {line: 2, column: 0}, end: {line: 2, column: 5}}}}]
 transformComments = (comments) ->
-  _.last _.reduce comments, ([state, accum], {loc, value}) ->
-    _.reduce _.initial(value.match /(?!\s).*/g), ([state, accum], line) ->
-      [..., prefix, value] = /^(>|[.]*)(.*)$/.exec line
+  _.last _.reduce comments, ([state, accum], comment, commentIndex) ->
+    _.reduce comment.value.split('\n'), ([state, accum], line, idx) ->
+      switch comment.type
+        when 'Block'
+          normalizedLine = line.replace /^\s*[*]?\s*/, ''
+          start = end = line: comment.loc.start.line + idx
+        when 'Line'
+          normalizedLine = line.replace /^\s*/, ''
+          {start, end} = comment.loc
+
+      [..., prefix, value] = /^(>|[.]*)(.*)$/.exec normalizedLine
       if prefix is '>'
-        [1, accum.concat input: {loc, value}]
+        [1, accum.concat {
+          commentIndex
+          input: {loc: {start, end}, value}
+        }]
       else if state is 0
         [0, accum]
       else if prefix
         [1, _.initial(accum).concat {
+          commentIndex
           input:
-            loc: start: _.last(accum).input.loc.start, end: loc.end
+            loc: {start: _.last(accum).input.loc.start, end}
             value: "#{_.last(accum).input.value}\n#{value}"
         }]
       else
         [0, _.initial(accum).concat {
+          commentIndex
           input: _.last(accum).input
-          output: {loc, value: line}
+          output: {loc: {start, end}, value}
         }]
     , [state, accum]
   , [0, []]
@@ -135,36 +147,79 @@ substring = (input, start, end) ->
 
 
 rewrite.js = (input) ->
-  # Locate all the comments within the input text, then use their
-  # positions to create a list containing all the code chunks. Note
-  # that if there are N comment chunks there are N + 1 code chunks.
-  # An empty comment at {line: Infinity, column: Infinity} enables
-  # the final code chunk to be captured.
-  {comments} = esprima.parse input, comment: yes, loc: yes
-  tests = transformComments comments
-  .concat input: value: '', loc: start: line: Infinity, column: Infinity
+  wrap = (test) ->
+    _.chain ['input', 'output']
+    .filter _.partial _.has, test
+    .map (type) -> wrap[type] test
+    .value()
+    .join '\n'
 
-  wrap =
-    input: (test) -> """
-      __doctest.input(function() {
-        return #{test.input.value};
-      });
-    """
-    output: (test) -> """
-      __doctest.output(#{test.output.loc.start.line}, function() {
-        return #{test.output.value};
-      });
-    """
+  wrap.input = (test) -> """
+    __doctest.input(function() {
+      return #{test.input.value};
+    });
+  """
+  wrap.output = (test) -> """
+    __doctest.output(#{test.output.loc.start.line}, function() {
+      return #{test.output.value};
+    });
+  """
 
-  _.chain tests
+  #  1. Locate block comments and line comments within the input text.
+  #
+  #  2. Create a list of comment chunks from the list of line comments
+  #     located in step 1 by grouping related comments.
+  #
+  #  3. Create a list of code chunks from the remaining input text.
+  #     Note that if there are N comment chunks there are N + 1 code
+  #     chunks. A trailing empty comment enables the final code chunk
+  #     to be captured:
+
+  bookend = value: '', loc: start: line: Infinity, column: Infinity
+
+  #  4. Map each comment chunk in the list produced by step 2 to a
+  #     string of JavaScript code derived from the chunk's doctests.
+  #
+  #  5. Zip the lists produced by steps 3 and 4; flatten; and join.
+  #
+  #  6. Find block comments in the source code produced by step 5.
+  #     (The locations of block comments located in step 1 are not
+  #     applicable to the rewritten source.)
+  #
+  #  7. Repeat steps 3 through 5 for the list of block comments
+  #     produced by step 6 (substituting "step 6" for "step 2").
+
+  getComments = (s) -> esprima.parse(s, comment: yes, loc: yes).comments
+  [blockTests, lineTests] = _.chain getComments input
+  .partition (c) -> c.type is 'Block'
+  .map transformComments
+  .value()
+
+  source = _.chain lineTests
+  .concat input: bookend
   .reduce ([chunks, start], test) ->
-    [chunks.concat substring input, start, test.input.loc.start
+    [[chunks..., substring input, start, test.input.loc.start]
      (test.output ? test.input).loc.end]
   , [[], {line: 1, column: 0}]
   .first()
-  .zip _.map tests, _.compose escodegen.generate, esprima.parse, (test) ->
-    (wrap[p] test for p in ['input', 'output'] when p of test).join('\n')
+  .zip _.map lineTests, wrap
   .flatten()
+  .value()
+  .join ''
+
+  _.chain getComments source
+  .filter (c) -> c.type is 'Block'
+  .concat bookend
+  .reduce ([chunks, start], comment, idx) ->
+    s = _.chain blockTests
+    .filter (t) -> t.commentIndex is idx
+    .map wrap
+    .value()
+    .join '\n'
+    [[chunks..., substring(source, start, comment.loc.start), s],
+     comment.loc.end]
+  , [[], {line: 1, column: 0}]
+  .first()
   .value()
   .join ''
 

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -71,11 +71,11 @@ testCommand 'bin/doctest test/shared/index.js',
   stdout: '''
     retrieving test/shared/index.js...
     running doctests in index.js...
-    ......x.x...........x.x
+    ......x.x...........x......x
     FAIL: expected 5 on line 31 (got 4)
     FAIL: expected TypeError on line 38 (got 0)
     FAIL: expected 9.5 on line 97 (got 5)
-    FAIL: expected "on automatic semicolon insertion" on line 109 (got "the rewriter should not rely")
+    FAIL: expected "on automatic semicolon insertion" on line 140 (got "the rewriter should not rely")
 
   '''
   stderr: ''
@@ -85,11 +85,11 @@ testCommand 'bin/doctest test/shared/index.coffee',
   stdout: '''
     retrieving test/shared/index.coffee...
     running doctests in index.coffee...
-    ......x.x...........x.x
+    ......x.x...........x......x
     FAIL: expected 5 on line 31 (got 4)
     FAIL: expected TypeError on line 38 (got 0)
     FAIL: expected 9.5 on line 97 (got 5)
-    FAIL: expected "on automatic semicolon insertion" on line 109 (got "the rewriter should not rely")
+    FAIL: expected "on automatic semicolon insertion" on line 140 (got "the rewriter should not rely")
 
   '''
   stderr: ''
@@ -99,18 +99,18 @@ testCommand 'bin/doctest test/shared/index.js test/shared/index.coffee',
   stdout: '''
     retrieving test/shared/index.js...
     running doctests in index.js...
-    ......x.x...........x.x
+    ......x.x...........x......x
     FAIL: expected 5 on line 31 (got 4)
     FAIL: expected TypeError on line 38 (got 0)
     FAIL: expected 9.5 on line 97 (got 5)
-    FAIL: expected "on automatic semicolon insertion" on line 109 (got "the rewriter should not rely")
+    FAIL: expected "on automatic semicolon insertion" on line 140 (got "the rewriter should not rely")
     retrieving test/shared/index.coffee...
     running doctests in index.coffee...
-    ......x.x...........x.x
+    ......x.x...........x......x
     FAIL: expected 5 on line 31 (got 4)
     FAIL: expected TypeError on line 38 (got 0)
     FAIL: expected 9.5 on line 97 (got 5)
-    FAIL: expected "on automatic semicolon insertion" on line 109 (got "the rewriter should not rely")
+    FAIL: expected "on automatic semicolon insertion" on line 140 (got "the rewriter should not rely")
 
   '''
   stderr: ''

--- a/test/shared/index.coffee
+++ b/test/shared/index.coffee
@@ -104,7 +104,38 @@ do ->
   # ..... .5
   # 1234.5
 
-  23: 'the rewriter should not rely on automatic semicolon insertion'
+  23: 'TODO: multiline comment'
+  #
+  # > 3 ** 3 - 2 ** 2
+  # 23
+  #
+
+  24: 'TODO: multiline comment with wrapped input'
+  #
+  # > (["foo", "bar", "baz"]
+  # .  .slice(0, -1)
+  # .  .join(" ")
+  # .  .toUpperCase())
+  # "FOO BAR"
+  #
+
+  25: 'JS ONLY: multiline comment with leading asterisks'
+  #
+  # > 1 + 2 * 3 * 4
+  # 25
+  # > 1 * 2 + 3 + 4 * 5
+  # 25
+  #
+
+  26: 'JS ONLY: multiline comment with leading asterisks and wrapped input'
+  #
+  # > (fib = (n) -> switch n
+  # .    when 0, 1 then n
+  # .    else fib(n - 2) + fib(n - 1)) 10
+  # 55
+  #
+
+  27: 'the rewriter should not rely on automatic semicolon insertion'
   # > "the rewriter should not rely"
   # "on automatic semicolon insertion"
   (4 + 4)

--- a/test/shared/index.js
+++ b/test/shared/index.js
@@ -104,7 +104,38 @@ global = 'global'
   // ..... .5
   // 1234.5
 
-  23, 'the rewriter should not rely on automatic semicolon insertion'
+  23, 'multiline comment'
+  /*
+     > Math.pow(3, 3) - Math.pow(2, 2)
+     23
+  */
+
+  24, 'multiline comment with wrapped input'
+  /*
+     > ["foo", "bar", "baz"]
+     . .slice(0, -1)
+     . .join(" ")
+     . .toUpperCase()
+     "FOO BAR"
+  */
+
+  25, 'multiline comment with leading asterisks'
+  /*
+   * > 1 + 2 * 3 * 4
+   * 25
+   * > 1 * 2 + 3 + 4 * 5
+   * 25
+   */
+
+  26, 'multiline comment with leading asterisks and wrapped input'
+  /*
+   * > (function fib(n) {
+   * .    return n == 0 || n == 1 ? n : fib(n - 2) + fib(n - 1);
+   * .  })(10)
+   * 55
+   */
+
+  27, 'the rewriter should not rely on automatic semicolon insertion'
   // > "the rewriter should not rely"
   // "on automatic semicolon insertion"
   (4 + 4)

--- a/test/shared/results.js
+++ b/test/shared/results.js
@@ -66,6 +66,21 @@
   ], [
     'wrapped lines may begin with more than one "."',
     [true, 1234.5, 1234.5, 105]
+  ], [
+    'multiline comment',
+    [true, 23, 23, 110]
+  ], [
+    'multiline comment with wrapped input',
+    [true, '"FOO BAR"', '"FOO BAR"', 119]
+  ], [
+    'multiline comment with leading asterisks',
+    [true, 25, 25, 125]
+  ], [
+    'multiline comment with leading asterisks',
+    [true, 25, 25, 127]
+  ], [
+    'multiline comment with leading asterisks and wrapped input',
+    [true, 55, 55, 135]
   ]];
 
   if (typeof window === 'undefined') {


### PR DESCRIPTION
Closes #27

This change proved significantly more involved than I first imagined, as it necessitated a second parsing phase.

While working on this change I realized that [escodegen](https://github.com/Constellation/escodegen) is not actually required: we needn't prettify code before testing it. :)

As always, I'd love to hear your feedback, @danse.
