### PR TITLE
handle empty substrings correctly

### DIFF
--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -153,6 +153,9 @@
 
   substring = function(input, start, end) {
     var combine;
+    if (start.line === end.line && start.column === end.column) {
+      return '';
+    }
     combine = function(a, b) {
       return ["" + a[0] + b[0], b[1]];
     };

--- a/src/doctest.coffee
+++ b/src/doctest.coffee
@@ -119,7 +119,10 @@ transformComments = (comments) ->
 #
 # > substring "hello\nworld", {line: 1, column: 3}, {line: 2, column: 2}
 # "lo\nwo"
+# > substring "hello\nworld", {line: 1, column: 0}, {line: 1, column: 0}
+# ""
 substring = (input, start, end) ->
+  return '' if start.line is end.line and start.column is end.column
   combine = (a, b) -> ["#{a[0]}#{b[0]}", b[1]]
   _.first _.reduce input.split(/^/m), (accum, line, idx) ->
     isStartLine = idx + 1 is start.line


### PR DESCRIPTION
In the process of investigating #29 I stumbled upon this nasty bug.

Given the following file:

``` javascript
// > identity("foobar")
// "foobar"
function identity(x) {
  return x;
}

// > constant(42)()
// 42
function constant(x) {
  return function() {
    return x;
  };
}
```

The rewriter produces:

``` javascript
// > identity("foobar")
// "foobar"
function identity(x) {
  return x;
}

// > constant(42)()
// 42
function constant(x) {
  return function() {
    return x;
  };
}
__doctest.input(function () {
    return identity('foobar');
});
__doctest.output(2, function () {
    return 'foobar';
});
function identity(x) {
  return x;
}

__doctest.input(function () {
    return constant(42)();
});
__doctest.output(8, function () {
    return 42;
});
function constant(x) {
  return function() {
    return x;
  };
}
__doctest.input(function () {
    return;
});
```

Note that the entire source appears verbatim at the beginning of the rewritten source, followed by the correctly rewritten source. This resulted from `substring` failing to handle empty substrings correctly, triggered here by a doctest appearing at the very beginning of the file.

Fortunately, the fix is straightforward. :)
