### PR TITLE
readme: add link to paolodm/grunt-doctest

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ It's easy to indicate that an error (of a particular kind) is expected:
 
 Each doctest has access to variables in its scope chain.
 
+### Integrations
+
+  - [Grunt](http://gruntjs.com/):
+      [paolodm/grunt-doctest](https://github.com/paolodm/grunt-doctest)
+
 ### Running the test suite
 
     $ make setup


### PR DESCRIPTION
Does this look good to you, @paolodm, or would you prefer the link to point to https://www.npmjs.org/package/grunt-doctest?
