### PR TITLE
ramda@0.8.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "coffee-script": "1.8.x",
     "esprima": "1.2.x",
     "jquery": "2.1.x",
-    "ramda": "0.3.x",
+    "ramda": "0.8.x",
     "underscore": "1.6.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "coffee-script": "1.8.x",
     "commander": "2.3.x",
     "esprima": "1.2.x",
-    "ramda": "0.3.x",
+    "ramda": "0.8.x",
     "underscore": "1.6.x"
   },
   "devDependencies": {


### PR DESCRIPTION
I may wait until 0.8.0 is published before merging this, as it'll obviate the need for two of the helper functions.

It's pleasing that defining `toPairs` for lists was enough to get rid of the uses of `R.reduce.idx`.
