### PR TITLE
Do not add CommonJS decorations twice

### DIFF
--- a/src/doctest.coffee
+++ b/src/doctest.coffee
@@ -368,19 +368,7 @@ functionEval = (source) ->
 
 commonjsEval = (source, path) ->
   abspath = pathlib.resolve(path).replace(/[.][^.]+$/, "-#{_.now()}.js")
-  fs.writeFileSync abspath, """
-    var __doctest = {
-      queue: [],
-      input: function(fn) {
-        __doctest.queue.push([fn]);
-      },
-      output: function(num, fn) {
-        __doctest.queue.push([fn, num]);
-      }
-    };
-    #{source}
-    (module.exports || exports).__doctest = __doctest;
-  """
+  fs.writeFileSync abspath, source
   try
     {queue} = require(abspath).__doctest
   finally


### PR DESCRIPTION
If `options.module` is `commonjs`, the same stuff is happenning in `toModule` and `commonjsEval` functions.

---

Steps to reproduce:

1․ Instrument `doctest` source a bit.

``` diff
diff --git a/src/doctest.coffee b/src/doctest.coffee
index 4a75c69..fedf69a 100644
--- a/src/doctest.coffee
+++ b/src/doctest.coffee
@@ -381,6 +381,7 @@ commonjsEval = (source, path) ->
     #{source}
     (module.exports || exports).__doctest = __doctest;
   """
+  console.log fs.readFileSync abspath, encoding: 'utf8'
   try
     {queue} = require(abspath).__doctest
   finally
```

2․ Run it on one of its built-in tests.

``` js
$ ./bin/doctest -m commonjs test/commonjs/exports/index.js
retrieving test/commonjs/exports/index.js...
running doctests in index.js...
var __doctest = {
  queue: [],
  input: function(fn) {
    __doctest.queue.push([fn]);
  },
  output: function(num, fn) {
    __doctest.queue.push([fn, num]);
  }
};
var __doctest = {
  queue: [],
  input: function(fn) {
    __doctest.queue.push([fn]);
  },
  output: function(num, fn) {
    __doctest.queue.push([fn, num]);
  }
};

__doctest.input(function() {
  return exports.identity(42);
});
__doctest.output(2, function() {
  return 42;
});
exports.identity = function(x) {
  return x;
};

(module.exports || exports).__doctest = __doctest;
(module.exports || exports).__doctest = __doctest;
.
```
