### PR TITLE
remove Underscore dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,7 @@ test/public/bundle.js: \
 		bower_components/esprima/esprima.js \
 		bower_components/jquery/dist/jquery.js \
 		bower_components/qunit/qunit/qunit.js \
-		bower_components/ramda/ramda.js \
-		bower_components/underscore/underscore.js \
+		bower_components/ramda/dist/ramda.js \
 		lib/doctest.js \
 		test/shared/results.js
 	mkdir -p $(@D)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ function toFahrenheit(degreesCelsius) {
 
         <script src="path/to/bower_components/esprima/esprima.js"></script>
         <script src="path/to/bower_components/jquery/dist/jquery.js"></script>
-        <script src="path/to/bower_components/underscore/underscore.js"></script>
+        <script src="path/to/bower_components/qunit/qunit/qunit.js"></script>
+        <script src="path/to/bower_components/ramda/dist/ramda.js"></script>
         <script src="path/to/bower_components/doctest/lib/doctest.js"></script>
 
 ### Running doctests

--- a/bower.json
+++ b/bower.json
@@ -13,8 +13,7 @@
     "coffee-script": "1.8.x",
     "esprima": "1.2.x",
     "jquery": "2.1.x",
-    "ramda": "0.8.x",
-    "underscore": "1.6.x"
+    "ramda": "0.10.x"
   },
   "devDependencies": {
     "qunit": "1.15.x"

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "coffee-script": "1.8.x",
     "commander": "2.5.x",
     "esprima": "1.2.x",
-    "ramda": "0.10.x",
-    "underscore": "1.6.x"
+    "ramda": "0.10.x"
   },
   "devDependencies": {
     "bower": "1.3.x",

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -1,5 +1,5 @@
 program = require 'commander'
-_       = require 'underscore'
+R       = require 'ramda'
 
 doctest = require '../lib/doctest'
 
@@ -15,20 +15,20 @@ program
 
 
 validators =
-  module: _.partial _.contains, [undefined, 'amd', 'commonjs']
-  print:  _.constant yes
-  silent: _.constant yes
-  type:   _.partial _.contains, [undefined, 'coffee', 'js']
+  module: R.contains R.__, [undefined, 'amd', 'commonjs']
+  print:  R.always yes
+  silent: R.always yes
+  type:   R.contains R.__, [undefined, 'coffee', 'js']
 
-keys = _.keys(validators).sort()
-options = _.pick program, keys
-_.each keys, (key) ->
+keys = R.keys(validators).sort()
+options = R.pick keys, program
+keys.forEach (key) ->
   unless validators[key] options[key]
     process.stderr.write "\n  error: invalid #{key} `#{options[key]}'\n\n"
     process.exit 1
 
 
-failures = _.reduce program.args, (failures, path) ->
+failures = R.reduce (failures, path) ->
   try
     results = doctest path, options
   catch err
@@ -36,7 +36,7 @@ failures = _.reduce program.args, (failures, path) ->
       # Format output to match commander.
       "\n  error: #{err.message[0].toLowerCase()}#{err.message[1..]}\n\n"
     process.exit 1
-  failures + _.reject(_.map(results, _.first), _.identity).length
-, 0
+  failures + R.length R.reject R.identity, R.map R.head, results
+, 0, program.args
 
 process.exit if failures is 0 then 0 else 1

--- a/src/doctest.coffee
+++ b/src/doctest.coffee
@@ -44,12 +44,11 @@ doctest.version = '0.7.1'
 
 
 if typeof window isnt 'undefined'
-  {_, CoffeeScript, esprima, R} = window
+  {CoffeeScript, esprima, R} = window
   window.doctest = doctest
 else
   fs = require 'fs'
   pathlib = require 'path'
-  _ = require 'underscore'
   CoffeeScript = require 'coffee-script'
   esprima = require 'esprima'
   R = require 'ramda'
@@ -419,7 +418,7 @@ functionEval = (source) ->
 
 
 commonjsEval = (source, path) ->
-  abspath = pathlib.resolve(path).replace(/[.][^.]+$/, "-#{_.now()}.js")
+  abspath = pathlib.resolve(path).replace(/[.][^.]+$/, "-#{Date.now()}.js")
   fs.writeFileSync abspath, source
   try
     {queue} = require(abspath).__doctest
@@ -439,7 +438,7 @@ run = (queue) ->
         actual = try input() catch error then error.constructor
         expected = arr[0]()
         results.push [
-          _.isEqual actual, expected
+          R.eqDeep actual, expected
           repr expected
           repr actual
           arr[1]

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -1,7 +1,7 @@
 {exec}  = require 'child_process'
 pathlib = require 'path'
 
-_       = require 'underscore'
+R       = require 'ramda'
 
 doctest = require '../lib/doctest'
 
@@ -15,7 +15,7 @@ unless process.env.NODE_DISABLE_COLORS or process.platform is 'win32'
 
 
 printResult = (actual, expected, message) ->
-  if _.isEqual actual, expected
+  if R.eqDeep actual, expected
     console.log "#{green} \u2714 #{gray} #{message}#{reset}"
   else
     console.warn  "#{red} \u2718 #{gray} #{message}#{reset}"
@@ -24,7 +24,7 @@ printResult = (actual, expected, message) ->
 
 
 testModule = (path, options) ->
-  doctest path, _.extend(silent: yes, options), (results) ->
+  doctest path, R.assoc('silent', yes, options), (results) ->
     for [message, expected], idx in require pathlib.resolve path, '../results'
       printResult results[idx], expected, message
 

--- a/test/index.html
+++ b/test/index.html
@@ -21,9 +21,9 @@
         doctest('shared/index.coffee', {}, callback);
       });
       function callback(results) {
-        _.each(window.results, function(expected, idx) {
+        R.forEachIndexed(function(expected, idx) {
           deepEqual(results[idx], expected[1], expected[0]);
-        });
+        }, window.results);
         start();
       }
     }());


### PR DESCRIPTION
Ramda's `eqDeep` is not identical to Underscore's `isEqual`, but should be equivalent for common comparisons.
