### PR TITLE
specify appropriate exit code in test/index.coffee

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
 install:
   - make setup


### PR DESCRIPTION
Switching to [`child_process.execSync`][1] (from [`child_process.exec`][2]) is not strictly necessary but it greatly simplifies matters. Since the function was added in [Node v0.12.0][3], the test suite can no longer be run on older versions.


[1]: https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options
[2]: https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
[3]: https://nodejs.org/en/blog/release/v0.12.0/
