### PR TITLE
switch actual and expected values in quadruples

### DIFF
--- a/src/doctest.coffee
+++ b/src/doctest.coffee
@@ -445,8 +445,8 @@ run = (queue) ->
         expected = arr[0]()
         results.push [
           R.eqDeep actual, expected
-          repr expected
           repr actual
+          repr expected
           arr[1]
         ]
         input = noop
@@ -455,7 +455,7 @@ run = (queue) ->
 
 log = (results) ->
   console.log R.join '', ((if pass then '.' else 'x') for [pass] in results)
-  for [pass, expected, actual, num] in results when not pass
+  for [pass, actual, expected, num] in results when not pass
     console.log "FAIL: expected #{expected} on line #{num} (got #{actual})"
   return
 

--- a/test/shared/results.js
+++ b/test/shared/results.js
@@ -20,13 +20,13 @@
     [true, [1, 2, 3], [1, 2, 3], 28]
   ], [
     'arithmetic error reported',
-    [false, 5, 4, 31]
+    [false, 4, 5, 31]
   ], [
     'TypeError captured and reported',
     [true, 'TypeError', 'TypeError', 35]
   ], [
     'TypeError expected but not reported',
-    [false, 'TypeError', 0, 38]
+    [false, 0, 'TypeError', 38]
   ], [
     'function accessible before declaration',
     [true, 12, 12, 42]
@@ -62,7 +62,7 @@
     [true, '"undefined"', '"undefined"', 92]
   ], [
     '"." should not follow leading "." in multiline expressions',
-    [false, 9.5, 5, 97]
+    [false, 5, 9.5, 97]
   ], [
     'wrapped lines may begin with more than one "."',
     [true, 1234.5, 1234.5, 105]


### PR DESCRIPTION
It's intuitive for the actual value to precede the expected value since the input precedes the expected output in the doctest itself.
