### PR TITLE
ramda@0.17.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,25 @@ Specify module system via command-line interface:
 
     $ doctest --module commonjs path/to/commonjs/module.js
 
-### Errors
+### Exceptions
 
-It's easy to indicate that an error (of a particular kind) is expected:
+An output line beginning with EXCLAMATION MARK (`!`) indicates that the
+preceding expression is expected to throw. The exclamation mark *must* be
+followed by SPACE (<code> </code>) and the name of an Error constructor.
+For example:
 
-    // > null.length
-    // TypeError
+```javascript
+// > null.length
+// ! TypeError
+```
+
+The constructor name *may* be followed by COLON (`:`), SPACE (<code> </code>),
+and the expected error message. For example:
+
+```javascript
+// > null.length
+// ! TypeError: Cannot read property 'length' of null
+```
 
 ### Scoping
 

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "coffee-script": "1.8.x",
     "jquery": "2.1.x",
-    "ramda": "0.15.x"
+    "ramda": "0.17.x"
   },
   "devDependencies": {
     "qunit": "1.15.x"

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "coffee-script": "1.8.x",
     "jquery": "2.1.x",
-    "ramda": "0.14.x"
+    "ramda": "0.15.x"
   },
   "devDependencies": {
     "qunit": "1.15.x"

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "coffee-script": "1.8.x",
     "jquery": "2.1.x",
-    "ramda": "0.13.x"
+    "ramda": "0.14.x"
   },
   "devDependencies": {
     "qunit": "1.15.x"

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "coffee-script": "1.8.x",
     "jquery": "2.1.x",
-    "ramda": "0.11.x"
+    "ramda": "0.13.x"
   },
   "devDependencies": {
     "qunit": "1.15.x"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "coffee-script": "1.8.x",
     "commander": "2.5.x",
     "esprima-fb": "13001.1001.0-dev-harmony-fb",
-    "ramda": "0.14.x"
+    "ramda": "0.15.x"
   },
   "devDependencies": {
     "bower": "1.3.x",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "coffee-script": "1.8.x",
     "commander": "2.5.x",
     "esprima-fb": "13001.1001.0-dev-harmony-fb",
-    "ramda": "0.11.x"
+    "ramda": "0.13.x"
   },
   "devDependencies": {
     "bower": "1.3.x",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "coffee-script": "1.8.x",
     "commander": "2.5.x",
     "esprima-fb": "13001.1001.0-dev-harmony-fb",
-    "ramda": "0.13.x"
+    "ramda": "0.14.x"
   },
   "devDependencies": {
     "bower": "1.3.x",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "coffee-script": "1.8.x",
     "commander": "2.5.x",
     "esprima-fb": "13001.1001.0-dev-harmony-fb",
-    "ramda": "0.15.x"
+    "ramda": "0.17.x"
   },
   "devDependencies": {
     "bower": "1.3.x",

--- a/src/doctest.coffee
+++ b/src/doctest.coffee
@@ -361,7 +361,7 @@ rewrite.coffee = (input) ->
     R.match /.*\n/g
     toPairs
     R.reduce ([literalChunks, commentChunks, inCommentChunk], [idx, line]) ->
-      isComment = /^[ \t]*#(?!##)/.test line
+      isComment = R.test /^[ \t]*#(?!##)/, line
       current = if isComment then commentChunks else literalChunks
       if isComment is inCommentChunk
         current[current.length - 1].value += line

--- a/src/doctest.coffee
+++ b/src/doctest.coffee
@@ -61,19 +61,28 @@ else
 appendTo = R.flip R.append
 
 
-# indentN :: Number -> String -> String
-indentN = R.pipe(
-  R.times R.always ' '
-  R.join ''
-  R.replace /^(?!$)/gm
-)
+# (b -> c) -> (a -> b) -> (a -> c)
+compose = R.curryN 2, R.compose
 
-# indent2 :: String -> String
-indent2 = indentN 2
+
+# fromMaybe :: a -> [a] -> a
+fromMaybe = R.curry (x, maybe) -> if R.isEmpty maybe then x else maybe[0]
+
+
+# indentN :: Number -> String -> String
+indentN = R.curry (n, s) -> R.replace /^(?!$)/gm, Array(n + 1).join(' '), s
+
+
+# joinLines :: [String] -> String
+joinLines = R.join '\n'
 
 
 # noop :: * -> ()
 noop = ->
+
+
+# quote :: String -> String
+quote = (s) -> "'#{R.replace /'/g, "\\'", s}'"
 
 
 # reduce :: a -> (a,b -> a) -> [b] -> a
@@ -123,16 +132,11 @@ toModule = (source, moduleType) -> switch moduleType
 
     """
   when 'commonjs'
-    iifeWrap = (s) -> "void function() {\n#{indent2 s}}.call(this);"
+    iifeWrap = (s) -> "void function() {\n#{indentN 2, s}}.call(this);"
     iifeWrap """
     var __doctest = {
       queue: [],
-      input: function(fn) {
-        __doctest.queue.push([fn]);
-      },
-      output: function(num, fn) {
-        __doctest.queue.push([fn, num]);
-      }
+      enqueue: function(io) { this.queue.push(io); }
     };
 
     #{iifeWrap source}
@@ -142,6 +146,31 @@ toModule = (source, moduleType) -> switch moduleType
     """
   else
     source
+
+
+# normalizeTest :: { output :: { value :: String } } ->
+#                    { ! :: Boolean, output :: { value :: String } }
+normalizeTest = R.converge(
+  R.call
+  R.pipe(R.of
+         R.filter R.has 'output'
+         R.map R.prop 'output'
+         R.map R.prop 'value'
+         R.map R.match /^![ ]?([^:]*)(?::[ ]?(.*))?$/
+         R.map R.ifElse(R.isNil
+                        R.always R.assoc '!', no
+                        R.converge(R.pipe(((t, m) -> "new #{t}(#{m})")
+                                          R.assocPath ['output', 'value']
+                                          compose R.assoc '!', yes)
+                                   R.nth 1
+                                   R.pipe(R.nth 2
+                                          R.of
+                                          R.reject R.isNil
+                                          R.map quote
+                                          fromMaybe '')))
+         fromMaybe R.identity)
+  R.identity
+)
 
 
 # transformComments :: [Object] -> [Object]
@@ -158,15 +187,16 @@ toModule = (source, moduleType) -> switch moduleType
 # .   value: ' 42'
 # .   loc: start: {line: 2, column: 0}, end: {line: 2, column: 5}
 # . ]
-# [
+# [ {
 # . commentIndex: 1
+# . '!': no
 # . input:
 # .   value: '6 * 7'
 # .   loc: start: {line: 1, column: 0}, end: {line: 1, column: 10}
 # . output:
 # .   value: '42'
 # .   loc: start: {line: 2, column: 0}, end: {line: 2, column: 5}
-# . ]
+# . } ]
 transformComments = R.pipe(
   toPairs
   reduce ['default', []], ([state, accum], [commentIndex, comment]) -> R.pipe(
@@ -217,6 +247,7 @@ transformComments = R.pipe(
           ['default', accum]
   ) comment
   R.last
+  R.map normalizeTest
 )
 
 
@@ -260,33 +291,49 @@ substring = (input, start, end) ->
 wrap = R.curry (type, test) -> R.pipe(
   R.filter R.has _, test
   R.map (dir) -> wrap[type][dir] test
-  R.join '\n'
+  joinLines
 ) ['input', 'output']
 
 wrap.js = wrap 'js'
 
 wrap.js.input = (test) -> """
-  __doctest.input(function() {
-    return #{test.input.value};
+  __doctest.enqueue({
+    type: 'input',
+    thunk: function() {
+      return #{test.input.value};
+    }
   });
 """
 
-wrap.js.output = (test) ->  """
-  __doctest.output(#{test.output.loc.start.line}, function() {
-    return #{test.output.value};
+wrap.js.output = (test) -> """
+  __doctest.enqueue({
+    type: 'output',
+    ':': #{test.output.loc.start.line},
+    '!': #{test['!']},
+    thunk: function() {
+      return #{test.output.value};
+    }
   });
 """
 
 wrap.coffee = wrap 'coffee'
 
 wrap.coffee.input = (test) -> """
-  __doctest.input ->
-  #{indent2 test.input.value}
+  __doctest.enqueue {
+    type: 'input'
+    thunk: ->
+  #{indentN 4, test.input.value}
+  }
 """
 
 wrap.coffee.output = (test) -> """
-  __doctest.output #{test.output.loc.start.line}, ->
-  #{indent2 test.output.value}
+  __doctest.enqueue {
+    type: 'output'
+    ':': #{test.output.loc.start.line}
+    '!': #{test['!']}
+    thunk: ->
+  #{indentN 4, test.output.value}
+  }
 """
 
 
@@ -346,7 +393,7 @@ rewrite.js = (input) ->
       R.pipe(
         R.filter R.propEq 'commentIndex', idx
         R.map wrap.js
-        R.join '\n'
+        joinLines
         appendTo R.append substring(source, start, comment.loc.start), chunks
         R.of
         R.append comment.loc.end
@@ -358,24 +405,23 @@ rewrite.js = (input) ->
 
 rewrite.coffee = (input) ->
   [literalChunks, commentChunks] = R.pipe(
-    R.match /.*\n/g
+    R.match /^.*(?=\n)/gm
     toPairs
     R.reduce ([literalChunks, commentChunks, inCommentChunk], [idx, line]) ->
       isComment = R.test /^[ \t]*#(?!##)/, line
       current = if isComment then commentChunks else literalChunks
       if isComment is inCommentChunk
-        current[current.length - 1].value += line
+        current[current.length - 1].lines.push line
       else
-        current[current.length] = value: line, loc: start: line: idx + 1
+        current[current.length] = lines: [line], loc: start: line: idx + 1
       [literalChunks, commentChunks, isComment]
-    , [[value: '', loc: start: line: 1], [], no]
+    , [[lines: [], loc: start: line: 1], [], no]
   ) input
 
-  matchLine = R.match /^([ \t]*)#[ \t]*(>|[.]*)(.*\n)/
+  matchLine = R.match /^([ \t]*)#[ \t]*(>|[.]*)[ ]?(.*)$/
   testChunks = R.map R.pipe(
     (commentChunk) -> R.pipe(
-      R.prop 'value'
-      R.match /.*\n/g
+      R.prop 'lines'
       toPairs
       reduce ['default', []], ([state, tests], [idx, line]) ->
         [indent, prefix, value] = R.tail matchLine line
@@ -383,7 +429,7 @@ rewrite.coffee = (input) ->
           tests[tests.length] = {indent, input: {value}}
           ['input', tests]
         else if prefix
-          tests[tests.length - 1][state].value += value
+          tests[tests.length - 1][state].value += "\n#{value}"
           [state, tests]
         else if state is 'input'
           loc = start: line: commentChunk.loc.start.line + idx
@@ -393,20 +439,15 @@ rewrite.coffee = (input) ->
           ['default', tests]
     ) commentChunk
     R.last
-    R.map R.converge(
-      R.apply
-      R.pipe R.prop('indent'), R.length, indentN
-      R.pipe wrap.coffee, R.of
-    )
-    R.join '\n'
+    R.map normalizeTest
+    R.map R.converge indentN, R.path(['indent', 'length']), wrap.coffee
+    joinLines
   ), commentChunks
 
-  R.pipe(
-    R.zip
-    R.flatten
-    R.join '\n'
-    CoffeeScript.compile
-  ) R.pluck('value', literalChunks), R.append('', testChunks)
+  CoffeeScript.compile joinLines R.flatten R.zip(
+    R.map R.compose(joinLines, R.prop 'lines'), literalChunks
+    R.append '', testChunks
+  )
 
 
 functionEval = (source) ->
@@ -417,9 +458,7 @@ functionEval = (source) ->
   # The `evaluate` function takes one argument, named `__doctest`.
   evaluate = Function '__doctest', source
   queue = []
-  evaluate
-    input: (fn) -> queue.push [fn]
-    output: (num, fn) -> queue.push [fn, num]
+  evaluate enqueue: (io) -> queue.push io
   run queue
 
 
@@ -434,22 +473,40 @@ commonjsEval = (source, path) ->
 
 
 run = (queue) ->
-  results = []; input = noop
-  for arr in queue
-    switch arr.length
-      when 1
-        input()
-        input = arr[0]
-      when 2
-        actual = try input() catch error then error.constructor
-        expected = arr[0]()
-        results.push [
+  results = []
+  thunks = []  # thunks :: Maybe (() -> *)
+  for io in queue
+    if io.type is 'input'
+      R.forEach R.call, thunks
+      thunks = [io.thunk]
+    else if io.type is 'output'
+      throws = no
+      actual = try
+        R.head R.map R.call, thunks
+      catch error
+        throws = yes
+        error
+      expected = io.thunk()
+
+      format = (err) ->
+        if expected.message and err.message
+          "! #{err.name}: #{err.message}"
+        else
+          "! #{err.name}"
+
+      results.push [
+        throws is io['!'] and
+        if R.is Error, actual
+          actual.constructor is expected.constructor and
+          (throws and not expected.message or
+           actual.message is expected.message)
+        else
           R.eqDeep actual, expected
-          repr actual
-          repr expected
-          arr[1]
-        ]
-        input = noop
+        (if throws then format else R.toString) actual
+        (if io['!'] then format else R.toString) expected
+        io[':']
+      ]
+      thunks = []
   results
 
 
@@ -458,20 +515,3 @@ log = (results) ->
   for [pass, actual, expected, num] in results when not pass
     console.log "FAIL: expected #{expected} on line #{num} (got #{actual})"
   return
-
-
-# > repr 'foo \\ bar \\ baz'
-# '"foo \\\\ bar \\\\ baz"'
-# > repr 'foo "bar" baz'
-# '"foo \\"bar\\" baz"'
-# > repr TypeError
-# 'TypeError'
-# > repr 42
-# 42
-repr = (val) -> switch Object::toString.call val
-  when '[object String]'
-    '"' + val.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
-  when '[object Function]'
-    val.name
-  else
-    val

--- a/test/amd/results.js
+++ b/test/amd/results.js
@@ -1,4 +1,4 @@
 module.exports = [[
   'doctest in AMD module',
-  [true, 32, 32, 5]
+  [true, '32', '32', 5]
 ]];

--- a/test/bin/results.js
+++ b/test/bin/results.js
@@ -1,4 +1,4 @@
 module.exports = [[
   'executable without file extension',
-  [true, 42, 42, 4]
+  [true, '42', '42', 4]
 ]];

--- a/test/commonjs/exports/results.js
+++ b/test/commonjs/exports/results.js
@@ -1,4 +1,4 @@
 module.exports = [[
   'exports',
-  [true, 42, 42, 2]
+  [true, '42', '42', 2]
 ]];

--- a/test/commonjs/module.exports/results.js
+++ b/test/commonjs/module.exports/results.js
@@ -1,4 +1,4 @@
 module.exports = [[
   'module.exports',
-  [true, 42, 42, 2]
+  [true, '42', '42', 2]
 ]];

--- a/test/commonjs/strict/results.js
+++ b/test/commonjs/strict/results.js
@@ -1,4 +1,4 @@
 module.exports = [[
   'preserves "use strict" directive',
-  [true, undefined, undefined, 4]
+  [true, 'undefined', 'undefined', 4]
 ]];

--- a/test/exceptions/index.js
+++ b/test/exceptions/index.js
@@ -1,0 +1,38 @@
+
+// > new Error('Invalid value')
+// new Error('Invalid value')
+
+// > new Error()
+// new Error('Invalid value')
+
+// > new Error('Invalid value')
+// new Error()
+
+// > new Error('Invalid value')
+// new Error('XXX')
+
+// > new Error('Invalid value')
+// ! Error: Invalid value
+
+// > sqrt(-1)
+// new Error('Invalid value')
+
+// > null.length
+// ! TypeError
+
+// > null.length
+// ! Error
+
+// > sqrt(-1)
+// ! Error: Invalid value
+
+// > sqrt(-1)
+// ! Error: XXX
+
+var sqrt = function(n) {
+  if (n >= 0) {
+    return Math.sqrt(n);
+  } else {
+    throw new Error('Invalid value');
+  }
+};

--- a/test/exceptions/results.js
+++ b/test/exceptions/results.js
@@ -1,0 +1,31 @@
+module.exports = [[
+  'input evaluates to Error with expected message',
+  [true, 'Error: Invalid value', 'Error: Invalid value', 3]
+], [
+  'input evaluates to Error without expected message',
+  [false, 'Error', 'Error: Invalid value', 6]
+], [
+  'input evaluates to Error with unexpected message',
+  [false, 'Error: Invalid value', 'Error', 9]
+], [
+  'input evaluates to Error with unexpected message',
+  [false, 'Error: Invalid value', 'Error: XXX', 12]
+], [
+  'evaluating input does not throw expected exception',
+  [false, 'Error: Invalid value', '! Error: Invalid value', 15]
+], [
+  'evaluating input throws unexpected exception',
+  [false, '! Error: Invalid value', 'Error: Invalid value', 18]
+], [
+  'evaluating input throws exception as expected, of expected type',
+  [true, '! TypeError', '! TypeError', 21]
+], [
+  'evaluating input throws exception as expected, of unexpected type',
+  [false, '! TypeError', '! Error', 24]
+], [
+  'evaluating input throws exception as expected, with expected message',
+  [true, '! Error: Invalid value', '! Error: Invalid value', 27]
+], [
+  'evaluating input throws exception as expected, with unexpected message',
+  [false, '! Error: Invalid value', '! Error: XXX', 30]
+]];

--- a/test/harmony/results.js
+++ b/test/harmony/results.js
@@ -1,7 +1,7 @@
 module.exports = [
-  ['seq.next().value', [true, 1, 1, 13]],
-  ['seq.next().value', [true, 1, 1, 15]],
-  ['seq.next().value', [true, 2, 2, 17]],
-  ['seq.next().value', [true, 3, 3, 19]],
-  ['seq.next().value', [true, 5, 5, 21]],
+  ['seq.next().value', [true, '1', '1', 13]],
+  ['seq.next().value', [true, '1', '1', 15]],
+  ['seq.next().value', [true, '2', '2', 17]],
+  ['seq.next().value', [true, '3', '3', 19]],
+  ['seq.next().value', [true, '5', '5', 21]],
 ];

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -28,9 +28,10 @@ printResult = (actual, expected, message) ->
 
 
 testModule = (path, options) ->
+  type = R.last R.split '.', path
   doctest path, R.assoc('silent', yes, options), (results) ->
     for [message, expected], idx in require pathlib.resolve path, '../results'
-      printResult results[idx], expected, message
+      printResult results[idx], expected, "#{message} [#{type}]"
 
 
 testCommand = (command, expected) ->
@@ -54,6 +55,7 @@ testModule 'test/line-endings/CR+LF.js'
 testModule 'test/line-endings/CR+LF.coffee'
 testModule 'test/line-endings/LF.js'
 testModule 'test/line-endings/LF.coffee'
+testModule 'test/exceptions/index.js'
 testModule 'test/amd/index.js', module: 'amd'
 testModule 'test/commonjs/require/index.js', module: 'commonjs'
 testModule 'test/commonjs/exports/index.js', module: 'commonjs'
@@ -84,7 +86,7 @@ testCommand 'bin/doctest test/shared/index.js',
     running doctests in index.js...
     ......x.x...........x........x
     FAIL: expected 5 on line 31 (got 4)
-    FAIL: expected TypeError on line 38 (got 0)
+    FAIL: expected ! TypeError on line 38 (got 0)
     FAIL: expected 9.5 on line 97 (got 5)
     FAIL: expected "on automatic semicolon insertion" on line 155 (got "the rewriter should not rely")
 
@@ -98,7 +100,7 @@ testCommand 'bin/doctest test/shared/index.coffee',
     running doctests in index.coffee...
     ......x.x...........x........x
     FAIL: expected 5 on line 31 (got 4)
-    FAIL: expected TypeError on line 38 (got 0)
+    FAIL: expected ! TypeError on line 38 (got 0)
     FAIL: expected 9.5 on line 97 (got 5)
     FAIL: expected "on automatic semicolon insertion" on line 155 (got "the rewriter should not rely")
 
@@ -112,14 +114,14 @@ testCommand 'bin/doctest test/shared/index.js test/shared/index.coffee',
     running doctests in index.js...
     ......x.x...........x........x
     FAIL: expected 5 on line 31 (got 4)
-    FAIL: expected TypeError on line 38 (got 0)
+    FAIL: expected ! TypeError on line 38 (got 0)
     FAIL: expected 9.5 on line 97 (got 5)
     FAIL: expected "on automatic semicolon insertion" on line 155 (got "the rewriter should not rely")
     retrieving test/shared/index.coffee...
     running doctests in index.coffee...
     ......x.x...........x........x
     FAIL: expected 5 on line 31 (got 4)
-    FAIL: expected TypeError on line 38 (got 0)
+    FAIL: expected ! TypeError on line 38 (got 0)
     FAIL: expected 9.5 on line 97 (got 5)
     FAIL: expected "on automatic semicolon insertion" on line 155 (got "the rewriter should not rely")
 
@@ -149,11 +151,19 @@ testCommand 'bin/doctest --module commonjs --silent src/doctest.coffee',
 testCommand 'bin/doctest --print test/commonjs/exports/index.js',
   status: 0
   stdout: '''
-    __doctest.input(function() {
-      return exports.identity(42);
+    __doctest.enqueue({
+      type: 'input',
+      thunk: function() {
+        return exports.identity(42);
+      }
     });
-    __doctest.output(2, function() {
-      return 42;
+    __doctest.enqueue({
+      type: 'output',
+      ':': 2,
+      '!': false,
+      thunk: function() {
+        return 42;
+      }
     });
     exports.identity = function(x) {
       return x;
@@ -168,11 +178,19 @@ testCommand 'bin/doctest --print --module amd test/amd/index.js',
     define(function() {
       // Convert degrees Celsius to degrees Fahrenheit.
       //
-      __doctest.input(function() {
-      return toFahrenheit(0);
+      __doctest.enqueue({
+      type: 'input',
+      thunk: function() {
+        return toFahrenheit(0);
+      }
     });
-    __doctest.output(5, function() {
-      return 32;
+    __doctest.enqueue({
+      type: 'output',
+      ':': 5,
+      '!': false,
+      thunk: function() {
+        return 32;
+      }
     });
       function toFahrenheit(degreesCelsius) {
         return degreesCelsius * 9 / 5 + 32;
@@ -198,20 +216,23 @@ testCommand 'bin/doctest --print --module commonjs test/commonjs/exports/index.j
     void function() {
       var __doctest = {
         queue: [],
-        input: function(fn) {
-          __doctest.queue.push([fn]);
-        },
-        output: function(num, fn) {
-          __doctest.queue.push([fn, num]);
-        }
+        enqueue: function(io) { this.queue.push(io); }
       };
 
       void function() {
-        __doctest.input(function() {
-          return exports.identity(42);
+        __doctest.enqueue({
+          type: 'input',
+          thunk: function() {
+            return exports.identity(42);
+          }
         });
-        __doctest.output(2, function() {
-          return 42;
+        __doctest.enqueue({
+          type: 'output',
+          ':': 2,
+          '!': false,
+          thunk: function() {
+            return 42;
+          }
         });
         exports.identity = function(x) {
           return x;

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -18,7 +18,7 @@ unless process.env.NODE_DISABLE_COLORS or process.platform is 'win32'
 failures = 0
 
 printResult = (actual, expected, message) ->
-  if R.eqDeep actual, expected
+  if R.equals actual, expected
     console.log "#{green} \u2714 #{gray} #{message}#{reset}"
   else
     failures += 1

--- a/test/index.html
+++ b/test/index.html
@@ -21,9 +21,10 @@
         doctest('shared/index.coffee', {}, callback);
       });
       function callback(results) {
-        R.forEachIndexed(function(expected, idx) {
-          deepEqual(results[idx], expected[1], expected[0]);
-        }, window.results);
+        R.forEach(R.apply(deepEqual),
+                  R.zipWith(R.prepend,
+                            results,
+                            R.map(R.reverse, window.results)));
         start();
       }
     }());

--- a/test/line-endings/results.js
+++ b/test/line-endings/results.js
@@ -1,4 +1,4 @@
 module.exports = [[
   'correct line number reported irrespective of line endings',
-  [true, 42, 42, 2]
+  [true, '42', '42', 2]
 ]];

--- a/test/shared/index.coffee
+++ b/test/shared/index.coffee
@@ -32,10 +32,10 @@ do ->
 
   8: 'TypeError captured and reported'
   # > null.length
-  # TypeError
+  # ! TypeError
   9: 'TypeError expected but not reported'
   # > [].length
-  # TypeError
+  # ! TypeError
 
   10: 'function accessible before declaration'
   # > double(6)

--- a/test/shared/index.js
+++ b/test/shared/index.js
@@ -32,10 +32,10 @@ global = 'global'
 
   8, 'TypeError captured and reported'
   // > null.length
-  // TypeError
+  // ! TypeError
   9, 'TypeError expected but not reported'
   // > [].length
-  // TypeError
+  // ! TypeError
 
   10, 'function accessible before declaration'
   // > double(6)

--- a/test/shared/results.js
+++ b/test/shared/results.js
@@ -11,34 +11,34 @@
     [true, '"shadowed"', '"shadowed"', 14]
   ], [
     'local variable accessible before declaration',
-    [true, 2, 2, 20]
+    [true, '2', '2', 20]
   ], [
     'assignment is an expression',
-    [true, 3, 3, 25]
+    [true, '3', '3', 25]
   ], [
     'variable declared in doctest remains accessible',
-    [true, [1, 2, 3], [1, 2, 3], 28]
+    [true, '[1, 2, 3]', '[1, 2, 3]', 28]
   ], [
     'arithmetic error reported',
-    [false, 4, 5, 31]
+    [false, '4', '5', 31]
   ], [
     'TypeError captured and reported',
-    [true, 'TypeError', 'TypeError', 35]
+    [true, '! TypeError', '! TypeError', 35]
   ], [
     'TypeError expected but not reported',
-    [false, 0, 'TypeError', 38]
+    [false, '0', '! TypeError', 38]
   ], [
     'function accessible before declaration',
-    [true, 12, 12, 42]
+    [true, '12', '12', 42]
   ], [
     'NaN can be used as expected result',
-    [true, NaN, NaN, 45]
+    [true, 'NaN', 'NaN', 45]
   ], [
     'function accessible after declaration',
-    [true, 4, 4, 53]
+    [true, '4', '4', 53]
   ], [
     'multiline input',
-    [true, [1, 2, 3, 4, 5, 6, 7, 8, 9], [1, 2, 3, 4, 5, 6, 7, 8, 9], 65]
+    [true, '[1, 2, 3, 4, 5, 6, 7, 8, 9]', '[1, 2, 3, 4, 5, 6, 7, 8, 9]', 65]
   ], [
     'multiline assignment',
     [true, '"input may span many lines"', '"input may span many lines"', 71]
@@ -50,43 +50,43 @@
     [true, '"Docco-compatible whitespace"', '"Docco-compatible whitespace"', 78]
   ], [
     '">" in doctest',
-    [true, true, true, 81]
+    [true, 'true', 'true', 81]
   ], [
     'comment on input line',
     [true, '"foobar"', '"foobar"', 85]
   ], [
     'comment on output line',
-    [true, 25, 25, 88]
+    [true, '25', '25', 88]
   ], [
     'variable in creation context is not accessible',
     [true, '"undefined"', '"undefined"', 92]
   ], [
     '"." should not follow leading "." in multiline expressions',
-    [false, 5, 9.5, 97]
+    [false, '5', '9.5', 97]
   ], [
     'wrapped lines may begin with more than one "."',
-    [true, 1234.5, 1234.5, 105]
+    [true, '1234.5', '1234.5', 105]
   ], [
     'multiline comment',
-    [true, 23, 23, 110]
+    [true, '23', '23', 110]
   ], [
     'multiline comment with wrapped input',
     [true, '"FOO BAR"', '"FOO BAR"', 119]
   ], [
     'multiline comment with leading asterisks',
-    [true, 25, 25, 125]
+    [true, '25', '25', 125]
   ], [
     'multiline comment with leading asterisks',
-    [true, 25, 25, 127]
+    [true, '25', '25', 127]
   ], [
     'multiline comment with leading asterisks and wrapped input',
-    [true, 55, 55, 135]
+    [true, '55', '55', 135]
   ], [
     'multiline output',
-    [true, ['foo', 'bar', 'baz'], ['foo', 'bar', 'baz'], 140]
+    [true, '["foo", "bar", "baz"]', '["foo", "bar", "baz"]', 140]
   ], [
     'multiline input with multiline output',
-    [true, ['FOO', 'BAR', 'BAZ'], ['FOO', 'BAR', 'BAZ'], 149]
+    [true, '["FOO", "BAR", "BAZ"]', '["FOO", "BAR", "BAZ"]', 149]
   ]];
 
   if (typeof window === 'undefined') {


### PR DESCRIPTION
This pull request allows doctests to leverage the full power of [`R.equals`][1]. For example:

```javascript
// > R.map(R.inc, S.Just(42))
// S.Just(43)
```

Previously one might have written:

```javascript
// > R.toString(R.map(R.inc, S.Just(42)))
// 'Just(43)'
```

This pull request also clarifies and enhances the testing of expected exceptions:

> __Exceptions__
>
> An output line beginning with EXCLAMATION MARK (`!`) indicates that the preceding expression is expected to throw. The exclamation mark *must* be followed by SPACE (<code> </code>) and the name of an Error constructor. For example:
>
> ```javascript
> // > null.length
> // ! TypeError
> ```
>
> The constructor name *may* be followed by COLON (`:`), SPACE (<code> </code>), and the expected error message. For example:
>
> ```javascript
> // > null.length
> // ! TypeError: Cannot read property 'length' of null
> ```


[1]: http://ramdajs.com/docs/#equals
