### PR TITLE
remove "version" property from module

### DIFF
--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-sed -i '' "s/version = '[^']*'/version = '$VERSION'/"   src/doctest.coffee
-git add                                                 src/doctest.coffee
-
 rm -f                                   lib/{command,doctest}.js
 make                                    lib/{command,doctest}.js
 git update-index --no-assume-unchanged  lib/{command,doctest}.js

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -2,10 +2,11 @@ program = require 'commander'
 R       = require 'ramda'
 
 doctest = require '../lib/doctest'
+pkg     = require '../package.json'
 
 
 program
-.version doctest.version
+.version pkg.version
 .usage '[options] path/to/js/or/coffee/module'
 .option '-m, --module <type>', 'specify module system ("amd" or "commonjs")'
 .option '    --nodejs', 'pass options directly to the "node" binary'

--- a/src/doctest.coffee
+++ b/src/doctest.coffee
@@ -40,8 +40,6 @@ doctest = (path, options = {}, callback = noop) ->
       callback results
       results
 
-doctest.version = '0.8.0'
-
 
 if typeof window isnt 'undefined'
   {CoffeeScript, esprima, R} = window


### PR DESCRIPTION
Including the `version` property adds complexity to the release process without much compensating benefit. One can still access the value in Node via `require('doctest/package.json').version`, and on the command-line via `doctest --version`.
