### PR TITLE
package.json: specify files to be included in tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,12 @@
     "jshint": "2.8.x",
     "semver": "4.3.x",
     "xyz": "0.5.x"
-  }
+  },
+  "files": [
+    "/bin/",
+    "/lib/",
+    "/LICENSE",
+    "/README.md",
+    "/package.json"
+  ]
 }


### PR DESCRIPTION
It's nice to exclude the tests and other unnecessary files from the distribution.
