### PR TITLE
ramda@0.18.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "coffee-script": "1.10.x",
     "jquery": "2.1.x",
-    "ramda": "0.17.x"
+    "ramda": "0.18.x"
   },
   "devDependencies": {
     "qunit": "1.19.x"

--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -19,7 +19,7 @@
       options = {};
     }
     if (callback == null) {
-      callback = noop;
+      callback = function() {};
     }
 
     var validateOption = function(name, validValues) {
@@ -85,9 +85,6 @@
   //  appendTo :: [a] -> a -> [a]
   var appendTo = R.flip(R.append);
 
-  //  compose :: (b -> c) -> (a -> b) -> (a -> c)
-  var compose = R.curryN(2, R.compose);
-
   //  fromMaybe :: a -> [a] -> a
   var fromMaybe = R.curry(function(x, maybe) {
     return R.isEmpty(maybe) ? x : maybe[0];
@@ -107,9 +104,6 @@
       R.match(/^\s*(>|[.]*)[ ]?(.*)$/, R.drop(prefix.length, s)) :
       null;
   });
-
-  //  noop :: * -> ()
-  var noop = function() {};
 
   //  quote :: String -> String
   var quote = function(s) {
@@ -189,8 +183,8 @@
 
   //  normalizeTest :: { output :: { value :: String } } ->
   //                     { ! :: Boolean, output :: { value :: String } }
-  var normalizeTest = R.converge(
-    R.call,
+  var normalizeTest = function(x) {
+    var f =
     R.pipe(R.of,
            R.filter(R.has('output')),
            R.map(R.prop('output')),
@@ -198,21 +192,17 @@
            R.map(R.match(/^![ ]?([^:]*)(?::[ ]?(.*))?$/)),
            R.map(R.ifElse(R.isEmpty,
                           R.always(R.assoc('!', false)),
-                          R.converge(R.pipe(function(type, message) {
-                                              return 'new ' + type +
-                                                     '(' + message + ')';
-                                            },
-                                            R.assocPath(['output', 'value']),
-                                            compose(R.assoc('!', true))),
-                                     R.nth(1),
-                                     R.pipe(R.nth(2),
-                                            R.of,
-                                            R.reject(R.isNil),
-                                            R.map(quote),
-                                            fromMaybe(''))))),
-           fromMaybe(R.identity)),
-    R.identity
-  );
+                          function(match) {
+                            var s = 'new ' + match[1] + '(' +
+                                    (match[2] == null ? '' : quote(match[2])) +
+                                    ')';
+                            return R.pipe(R.assocPath(['output', 'value'], s),
+                                          R.assoc('!', true));
+                          })),
+           fromMaybe(R.identity));
+
+    return f(x)(x);
+  };
 
 
   var _commentIndex = R.lensProp('commentIndex');
@@ -337,9 +327,7 @@
                 [R.concat(accum[0], chr), true] :
                 [accum[0], false];
             }),
-            R.converge(R.prepend,
-                       R.pipe(R.head, R.concat(R.head(accum))),
-                       R.tail)
+            R.over(_1, R.concat(R.head(accum)))
           )(line);
         }),
         R.head
@@ -433,7 +421,7 @@
     //     produced by step 6 (substituting "step 6" for "step 2").
 
     var getComments =
-    R.pipe(R.partialRight(esprima.parse, {comment: true, loc: true}),
+    R.pipe(R.partialRight(esprima.parse, [{comment: true, loc: true}]),
            R.prop('comments'));
 
     //  tests :: { blockTests :: [Test], lineTests :: [Test] }
@@ -534,7 +522,7 @@
       },
       R.last,
       R.map(normalizeTest),
-      R.map(R.converge(indentN, R.path(['indent', 'length']), wrap.coffee)),
+      R.map(R.lift(indentN)(R.path(['indent', 'length']), wrap.coffee)),
       joinLines
     ), chunks.commentChunks);
 
@@ -612,15 +600,15 @@
     return results;
   };
 
-  var log =
-  R.converge(noop,
-             R.pipe(R.map(R.ifElse(R.head, R.always('.'), R.always('x'))),
-                    R.join(''),
-                    R.bind(console.log, console)),
-             R.pipe(R.reject(R.head),
-                    R.forEach(R.apply(function(pass, actual, expected, num) {
-                      console.log('FAIL: expected ' + expected +
-                                  ' on line ' + num + ' (got ' + actual + ')');
-                    }))));
+  var log = function(results) {
+    console.log(R.join('',
+                       R.map(R.ifElse(R.head, R.always('.'), R.always('x')),
+                             results)));
+    R.forEach(R.apply(function(pass, actual, expected, num) {
+                console.log('FAIL: expected ' + expected +
+                            ' on line ' + num + ' (got ' + actual + ')');
+              }),
+              R.reject(R.head, results));
+  };
 
 }.call(this, this));

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "coffee-script": "1.10.x",
     "commander": "2.8.x",
     "esprima": "2.6.x",
-    "ramda": "0.17.x"
+    "ramda": "0.18.x"
   },
   "devDependencies": {
     "bower": "1.5.x",


### PR DESCRIPTION
ramda/ramda#1436

In v0.18.0, `R.converge` became a binary function (rather than a variadic function).

The following are equivalent:

```javascript
//  v0.17.x
R.converge(Math.pow, R.dec, R.inc)(3)

//  v0.18.x
R.converge(Math.pow, [R.dec, R.inc])(3)

//  v0.18.x
R.lift(Math.pow)(R.dec, R.inc)(3)
```

I decided to replace all occurrences of `R.converge(f)`. Some I replaced with `R.lift(f)`; others I replaced with lambdas.

Mind taking a look at this, @danse?
