### PR TITLE
use Z.equals for equality checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ test/public/bundle.js: \
 		bower_components/jquery/dist/jquery.js \
 		bower_components/qunit/qunit/qunit.js \
 		bower_components/ramda/dist/ramda.js \
+		bower_components/sanctuary-type-identifiers/index.js \
+		bower_components/sanctuary-type-classes/index.js \
 		lib/doctest.js \
 		test/shared/results.js
 	mkdir -p $(@D)

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "coffee-script": "1.10.x",
     "jquery": "2.1.x",
-    "ramda": "0.19.x"
+    "ramda": "0.19.x",
+    "sanctuary-type-classes": "4.0.x",
+    "sanctuary-type-identifiers": "1.0.x"
   },
   "devDependencies": {
     "qunit": "1.19.x"

--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -58,11 +58,13 @@
   }
 
 
-  var CoffeeScript, R, esprima;
+  var CoffeeScript, R, Z, esprima, type;
   if (typeof window !== 'undefined') {
     CoffeeScript = global.CoffeeScript;
     esprima = global.esprima;
     R = global.R;
+    Z = global.sanctuaryTypeClasses;
+    type = global.sanctuaryTypeIdentifiers;
     global.doctest = doctest;
   } else {
     var fs = require('fs');
@@ -70,6 +72,8 @@
     CoffeeScript = require('coffee-script');
     esprima = require('esprima');
     R = require('ramda');
+    Z = require('sanctuary-type-classes');
+    type = require('sanctuary-type-identifiers');
     module.exports = doctest;
   }
 
@@ -108,7 +112,9 @@
   var reduce = R.flip(R.addIndex(R.reduce));
 
   //  show :: a -> String
-  var show = R.toString;
+  function show(x) {
+    return type(x) === 'Error' ? String(x) : Z.toString(x);
+  }
 
   //  startsWith :: String -> String -> Boolean
   var startsWith = R.curry(function(prefix, s) {
@@ -592,12 +598,12 @@
 
         results.push([
           throws === io['!'] &&
-          (R.is(Error, actual) ?
-             actual.constructor === expected.constructor &&
-             (throws && !expected.message ||
-              actual.message === expected.message) :
+          (throws ?
+             type(actual) === 'Error' &&
+             actual.name === expected.name &&
+             (expected.message === '' || actual.message === expected.message) :
            // else
-             R.equals(actual, expected)),
+             Z.equals(actual, expected)),
           (throws ? formatError(expected.message !== '') : show)(actual),
           (io['!'] ? formatError(expected.message !== '') : show)(expected),
           io[':']

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "coffee-script": "1.10.x",
     "commander": "2.8.x",
     "esprima": "3.1.x",
-    "ramda": "0.19.x"
+    "ramda": "0.19.x",
+    "sanctuary-type-classes": "4.0.x",
+    "sanctuary-type-identifiers": "1.0.x"
   },
   "devDependencies": {
     "bower": "1.5.x",

--- a/test/fantasy-land/index.js
+++ b/test/fantasy-land/index.js
@@ -1,0 +1,16 @@
+// > Absolute(-1)
+// Absolute(1)
+function Absolute(n) {
+  if (!(this instanceof Absolute)) return new Absolute(n);
+  this.value = n;
+}
+
+Absolute['@@type'] = 'doctest/Absolute';
+
+Absolute.prototype.toString = function() {
+  return 'Absolute(' + this.value + ')';
+};
+
+Absolute.prototype['fantasy-land/equals'] = function(other) {
+  return Math.abs(this.value) === Math.abs(other.value);
+};

--- a/test/fantasy-land/results.js
+++ b/test/fantasy-land/results.js
@@ -1,0 +1,4 @@
+module.exports = [[
+  'uses Z.equals for equality checks',
+  [true, 'Absolute(-1)', 'Absolute(1)', 2]
+]];

--- a/test/index.js
+++ b/test/index.js
@@ -75,6 +75,7 @@ testModule('test/line-endings/LF.js');
 testModule('test/line-endings/LF.coffee');
 testModule('test/exceptions/index.js');
 testModule('test/statements/index.js');
+testModule('test/fantasy-land/index.js');
 testModule('test/transcribe/index.js', {prefix: '.'});
 testModule('test/transcribe/index.coffee', {prefix: '.'});
 testModule('test/amd/index.js', {module: 'amd'});


### PR DESCRIPTION
Ramda currently supports an old version of the [Fantasy Land][1] specification (ramda/ramda#1900). In order to use doctest with types which target more recent versions of the specification we must use [`Z.equals`][2] in place of [`R.equals`][3].


[1]: https://github.com/fantasyland/fantasy-land
[2]: https://github.com/sanctuary-js/sanctuary-type-classes/tree/v4.0.0#equals
[3]: http://ramdajs.com/0.19.1/docs/#equals
