### PR TITLE
expose ‘require’ as ‘__doctest.require’

### DIFF
--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -172,6 +172,7 @@
       case 'commonjs':
         return iifeWrap(unlines([
           'var __doctest = {',
+          '  require: require,',
           '  queue: [],',
           '  enqueue: function(io) { this.queue.push(io); }',
           '};',

--- a/test/index.js
+++ b/test/index.js
@@ -249,6 +249,7 @@ testCommand(
   stdout: unlines([
     'void function() {',
     '  var __doctest = {',
+    '    require: require,',
     '    queue: [],',
     '    enqueue: function(io) { this.queue.push(io); }',
     '  };',


### PR DESCRIPTION
See sanctuary-js/sanctuary#470 for the motivation behind this addition.
