### PR TITLE
remove Ramda dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ all:
 .PHONY: lint
 lint:
 	$(ESLINT) \
-	  --rule 'key-spacing: [off]' \
 	  -- lib/command.js
 	$(ESLINT) \
 	  --rule 'no-multiple-empty-lines: [error, {max: 2, maxEOF: 0}]' \

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var program = require('commander');
-var R = require('ramda');
 
 var doctest = require('..');
 var pkg = require('../package.json');
@@ -18,34 +17,37 @@ program
 .option('-t, --type <type>', 'specify file type ("coffee" or "js")')
 .parse(process.argv);
 
-var validators = {
-  module: R.contains(R.__, [undefined, 'amd', 'commonjs']),
-  prefix: R.T,
-  print:  R.T,
-  silent: R.T,
-  type:   R.contains(R.__, [undefined, 'coffee', 'js'])
-};
+//  formatErrors :: NonEmpty (Array String) -> String
+function formatErrors(errors) {
+  return [''].concat(errors).join('\n  error: ') + '\n\n';
+}
 
-var keys = R.keys(validators).sort();
-var options = R.pick(keys, program);
-keys.forEach(function(key) {
-  if (!validators[key](options[key])) {
-    process.stderr.write('\n  error: invalid ' + key +
-                         ' `' + options[key] + "'\n\n");
-    process.exit(1);
-  }
-});
+var errors = [];
+if (program.module != null &&
+    program.module !== 'amd' &&
+    program.module !== 'commonjs') {
+  errors.push('invalid module `' + program.module + "'");
+}
+if (program.type != null &&
+    program.type !== 'coffee' &&
+    program.type !== 'js') {
+  errors.push('invalid type `' + program.type + "'");
+}
+if (errors.length > 0) {
+  process.stderr.write(formatErrors(errors));
+  process.exit(1);
+}
 
-var failures = R.reduce(function(failures, path) {
+process.exit(program.args.reduce(function(status, path) {
   var results;
   try {
-    results = doctest(path, options);
+    results = doctest(path, program);
   } catch (err) {
-    process.stderr.write('\n  error: ' + err.message[0].toLowerCase() +
-                         err.message.slice(1) + '\n\n');
+    var msg = err.message;
+    process.stderr.write(formatErrors([msg[0].toLowerCase() + msg.slice(1)]));
     process.exit(1);
   }
-  return failures + R.length(R.reject(R.identity, R.map(R.head, results)));
-}, 0, program.args);
-
-process.exit(failures === 0 ? 0 : 1);
+  return results.reduce(function(status, tuple) {
+    return tuple[0] ? status : 1;
+  }, status);
+}, 0));

--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -15,9 +15,7 @@ var pathlib = require('path');
 
 var CoffeeScript = require('coffee-script');
 var esprima = require('esprima');
-var R = require('ramda');
 var Z = require('sanctuary-type-classes');
-var type = require('sanctuary-type-identifiers');
 
 
 function inferType(path) {
@@ -28,6 +26,8 @@ function inferType(path) {
   }
 }
 
+var rewriters = {coffee: rewrite$coffee, js: rewrite$js};
+
 function evaluate(moduleType, source, path) {
   return moduleType === 'commonjs' ?
     commonjsEval(source, path) :
@@ -35,24 +35,29 @@ function evaluate(moduleType, source, path) {
 }
 
 module.exports = function(path, options) {
-  function validateOption(name, validValues) {
-    if (R.has(name, options) && !R.contains(options[name], validValues)) {
-      throw new Error('Invalid ' + name + ' `' + options[name] + "'");
-    }
+  if (options.module != null &&
+      options.module !== 'amd' &&
+      options.module !== 'commonjs') {
+    throw new Error('Invalid module `' + options.module + "'");
+  }
+  if (options.type != null &&
+      options.type !== 'coffee' &&
+      options.type !== 'js') {
+    throw new Error('Invalid type `' + options.type + "'");
   }
 
-  validateOption('module', ['amd', 'commonjs']);
-  validateOption('type', ['coffee', 'js']);
-
   var source = toModule(
-    rewrite(options.type == null ? inferType(path) : options.type,
-            R.defaultTo('', options.prefix),
-            fs.readFileSync(path, 'utf8')),
+    rewriters[options.type == null ? inferType(path) : options.type](
+      options.prefix == null ? '' : options.prefix,
+      fs.readFileSync(path, 'utf8')
+        .replace(/\r\n?/g, '\n')
+        .replace(/^#!.*/, '')
+    ),
     options.module
   );
 
   if (options.print) {
-    console.log(R.replace(/\n$/, '', source));
+    console.log(source.replace(/\n$/, ''));
     return [];
   } else if (options.silent) {
     return evaluate(options.module, source, path);
@@ -64,55 +69,33 @@ module.exports = function(path, options) {
   }
 };
 
-var _ = R.__;
+//  indentN :: (Integer, String) -> String
+function indentN(n, s) {
+  return s.replace(/^(?!$)/gm, Array(n + 1).join(' '));
+}
 
-//  appendTo :: Array a -> a -> Array a
-var appendTo = R.flip(R.append);
-
-//  fromMaybe :: a -> Array a -> a
-var fromMaybe = R.curry(function(x, maybe) {
-  return R.isEmpty(maybe) ? x : maybe[0];
-});
-
-//  indentN :: Integer -> String -> String
-var indentN = R.curry(function(n, s) {
-  return R.replace(/^(?!$)/gm, Array(n + 1).join(' '), s);
-});
-
-//  joinLines :: Array String -> String
-var joinLines = R.join('\n');
-
-//  matchLine :: String -> String -> Nullable (Array3 String String String)
-var matchLine = R.curry(function(prefix, s) {
-  return startsWith(prefix, s) ?
-    R.match(/^\s*(>|[.]*)[ ]?(.*)$/, R.drop(prefix.length, s)) :
+//  matchLine :: (String, String) -> Nullable (Array3 String String String)
+function matchLine(prefix, s) {
+  return s.slice(0, prefix.length) === prefix ?
+    s.slice(prefix.length).match(/^\s*(>|[.]*)[ ]?(.*)$/) :
     null;
-});
+}
 
 //  quote :: String -> String
 function quote(s) {
-  return "'" + R.replace(/'/g, "\\'", s) + "'";
+  return "'" + s.replace(/'/g, "\\'") + "'";
 }
-
-//  reduce :: a -> ((a, b, Integer, Array b) -> a) -> Array b -> a
-var reduce = R.flip(R.addIndex(R.reduce));
 
 //  show :: a -> String
 function show(x) {
-  return type(x) === 'Error' ? String(x) : Z.toString(x);
+  return Object.prototype.toString.call(x) === '[object Error]' ?
+    String(x) :
+    Z.toString(x);
 }
 
-//  startsWith :: String -> String -> Boolean
-var startsWith = R.curry(function(prefix, s) {
-  return R.take(prefix.length, s) === prefix;
-});
-
 //  unlines :: Array String -> String
-var unlines = R.compose(R.join(''), R.map(R.concat(R.__, '\n')));
-
-function rewrite(type, prefix, input) {
-  return rewrite[type](prefix,
-                       input.replace(/\r\n?/g, '\n').replace(/^#!.*/, ''));
+function unlines(lines) {
+  return lines.reduce(function(s, line) { return s + line + '\n'; }, '');
 }
 
 //  iifeWrap :: String -> String
@@ -152,58 +135,28 @@ function toModule(source, moduleType) {
   }
 }
 
-//  normalizeTest :: { output :: { value :: String } } ->
-//                     { ! :: Boolean, output :: { value :: String } }
-function normalizeTest(x) {
-  var f =
-  R.pipe(R.of,
-         R.filter(R.has('output')),
-         R.map(R.prop('output')),
-         R.map(R.prop('value')),
-         R.map(R.match(/^![ ]?([^:]*)(?::[ ]?(.*))?$/)),
-         R.map(R.ifElse(R.isEmpty,
-                        R.always(R.assoc('!', false)),
-                        function(match) {
-                          var s = 'new ' + match[1] + '(' +
-                                  (match[2] == null ? '' : quote(match[2])) +
-                                  ')';
-                          return R.pipe(R.assocPath(['output', 'value'], s),
-                                        R.assoc('!', true));
-                        })),
-         fromMaybe(R.identity));
-
-  return f(x)(x);
+//  normalizeTest :: { output :: { value :: String } } -> Undefined
+function normalizeTest($test) {
+  var $output = $test.output;
+  if ($output != null) {
+    var match = $output.value.match(/^![ ]?([^:]*)(?::[ ]?(.*))?$/);
+    $test['!'] = match != null;
+    if ($test['!']) {
+      $output.value = 'new ' + match[1] + '(' + quote(match[2] || '') + ')';
+    }
+  }
 }
 
-var _commentIndex = R.lensProp('commentIndex');
-var _end          = R.lensProp('end');
-var _input        = R.lensProp('input');
-var _loc          = R.lensProp('loc');
-var _output       = R.lensProp('output');
-var _value        = R.lensProp('value');
-var _1            = R.lensIndex(0);
-var _2            = R.lensIndex(1);
-
-_2._last = R.compose(_2, R.lens(R.last, function(x, xs) {
-  return R.update(xs.length - 1, x, xs);
-}));
-
-_2._last.commentIndex   = R.compose(_2._last, _commentIndex);
-_2._last.output         = R.compose(_2._last, _output);
-_2._last.output.loc     = R.compose(_2._last.output, _loc);
-_2._last.output.loc.end = R.compose(_2._last.output.loc, _end);
-_2._last.output.value   = R.compose(_2._last.output, _value);
-_2._last.input          = R.compose(_2._last, _input);
-_2._last.input.loc      = R.compose(_2._last.input, _loc);
-_2._last.input.loc.end  = R.compose(_2._last.input.loc, _end);
-_2._last.input.value    = R.compose(_2._last.input, _value);
+var INPUT = 'input';
+var OUTPUT = 'output';
+var DEFAULT = 'default';
 
 //  Location = { start :: { line :: Integer, column :: Integer }
 //             ,   end :: { line :: Integer, column :: Integer } }
 
 //  transformComments
-//  :: String
-//  -> Array { type :: String, value :: String, loc :: Location }
+//  :: ( String
+//      , Array { type :: String, value :: String, loc :: Location } )
 //  -> Array { commentIndex :: Integer
 //           ,            ! :: Boolean
 //           ,        input :: { value :: String, loc :: Location }
@@ -230,52 +183,51 @@ _2._last.input.value    = R.compose(_2._last.input, _value);
 //  .     value: '42',
 //  .     loc: {start: {line: 2, column: 0}, end: {line: 2, column: 5}}}
 //  . }]
-var transformComments = R.curry(function(prefix, comments) {
-  function gather(accum, comment, commentIndex) {
-    return R.pipe(
-      R.prop('value'),
-      R.split('\n'),
-      reduce(accum, function(accum, line, idx) {
-        var normalizedLine, start, end;
-        if (comment.type === 'Block') {
-          normalizedLine = R.replace(/^\s*[*]?\s*/, '', line);
-          start = end = {line: comment.loc.start.line + idx};
-        } else if (comment.type === 'Line') {
-          normalizedLine = R.replace(/^\s*/, '', line);
-          start = comment.loc.start;
-          end = comment.loc.end;
+function transformComments(prefix, comments) {
+  var result = comments.reduce(function(accum, comment, commentIndex) {
+    return comment.value.split('\n').reduce(function(accum, line, idx) {
+      var normalizedLine, start, end;
+      if (comment.type === 'Block') {
+        normalizedLine = line.replace(/^\s*[*]?\s*/, '');
+        start = end = {line: comment.loc.start.line + idx};
+      } else if (comment.type === 'Line') {
+        normalizedLine = line.replace(/^\s*/, '');
+        start = comment.loc.start;
+        end = comment.loc.end;
+      }
+
+      var match = matchLine(prefix, normalizedLine);
+      if (match != null) {
+        var $1 = match[1];
+        var $2 = match[2];
+        if ($1 === '>') {
+          accum.state = INPUT;
+          accum.tests.push({
+            commentIndex: commentIndex,
+            input: {value: $2, loc: {start: start, end: end}}
+          });
+        } else if ($1 !== '' || accum.state === INPUT) {
+          var last = accum.tests[accum.tests.length - 1];
+          last.commentIndex = commentIndex;
+          if ($1 !== '') {
+            last[accum.state].value += '\n' + $2;
+            last[accum.state].loc.end = end;
+          } else {
+            accum.state = OUTPUT;
+            last[accum.state] = {value: $2, loc: {start: start, end: end}};
+          }
+        } else {
+          accum.state = DEFAULT;
         }
+      }
+      return accum;
+    }, accum);
+  }, {state: DEFAULT, tests: []});
 
-        var match = matchLine(prefix, normalizedLine);
-        return (
-          match == null ?
-            R.identity :
-          match[1] === '>' ?
-            R.pipe(R.set(_1, 'input'),
-                   R.over(_2, R.append({})),
-                   R.set(_2._last.commentIndex, commentIndex),
-                   R.set(_2._last.input,
-                         {loc: {start: start, end: end}, value: match[2]})) :
-          match[1] ?
-            R.pipe(R.set(_2._last.commentIndex, commentIndex),
-                   R.set(_2._last[accum[0]].loc.end, end),
-                   R.over(_2._last[accum[0]].value,
-                          R.concat(_, '\n' + match[2]))) :
-          accum[0] === 'input' ?
-            R.pipe(R.set(_1, 'output'),
-                   R.set(_2._last.commentIndex, commentIndex),
-                   R.set(_2._last.output,
-                         {loc: {start: start, end: end}, value: match[2]})) :
-          // else
-            R.set(_1, 'default')
-        )(accum);
-      })
-    )(comment);
-  }
-
-  return R.map(normalizeTest,
-               R.nth(1, reduce(['default', []], gather, comments)));
-});
+  var $tests = result.tests;
+  $tests.forEach(normalizeTest);
+  return $tests;
+}
 
 //  substring
 //  :: ( String
@@ -292,82 +244,51 @@ var transformComments = R.curry(function(prefix, comments) {
 //  > substring('hello\nworld', {line: 1, column: 0}, {line: 1, column: 0})
 //  ''
 function substring(input, start, end) {
-  return start.line === end.line && start.column === end.column ?
-    '' :
-    R.pipe(
-      R.split(/^/m),
-      reduce(['', false], function(accum, line, idx) {
-        var isStartLine = idx + 1 === start.line;
-        var isEndLine = idx + 1 === end.line;
-        return R.pipe(
-          R.split(''),
-          reduce(['', R.last(accum)], function(accum, chr, column) {
-            return isStartLine && column === start.column ||
-                   accum[1] && !(isEndLine && column === end.column) ?
-              [R.concat(accum[0], chr), true] :
-              [accum[0], false];
-          }),
-          R.over(_1, R.concat(R.head(accum)))
-        )(line);
-      }),
-      R.head
-    )(input);
+  var lines = input.split(/^/m);
+  return (
+    start.line === end.line ?
+      lines[start.line - 1].slice(start.column, end.column) :
+    end.line === Infinity ?
+      lines[start.line - 1].slice(start.column) +
+      lines.slice(start.line).join('') :
+    // else
+      lines[start.line - 1].slice(start.column) +
+      lines.slice(start.line, end.line - 1).join('') +
+      lines[end.line - 1].slice(0, end.column)
+  );
 }
 
-var wrap = R.curry(function(type, test) {
-  return R.pipe(R.filter(R.has(_, test)), R.map(function(dir) {
-    return wrap[type][dir](test);
-  }), joinLines)(['input', 'output']);
-});
+function wrap$js(test) {
+  var type = esprima.parse(test.input.value).body[0].type;
+  return type === 'FunctionDeclaration' || type === 'VariableDeclaration' ?
+    test.input.value :
+    [
+      '__doctest.enqueue({',
+      '  type: "input",',
+      '  thunk: function() {',
+      '    return ' + test.input.value + ';',
+      '  }',
+      '});'
+    ].concat(test.output == null ? [] : [
+      '__doctest.enqueue({',
+      '  type: "output",',
+      '  ":": ' + test.output.loc.start.line + ',',
+      '  "!": ' + test['!'] + ',',
+      '  thunk: function() {',
+      '    return ' + test.output.value + ';',
+      '  }',
+      '});'
+    ]).join('\n');
+}
 
-wrap.js = function(test) {
-  switch (esprima.parse(test.input.value).body[0].type) {
-    case 'FunctionDeclaration':
-    case 'VariableDeclaration':
-      return test.input.value;
-    default:
-      return wrap('js', test);
-  }
-};
-
-wrap.js.input = function(test) {
-  return joinLines([
-    '__doctest.enqueue({',
-    '  type: "input",',
-    '  thunk: function() {',
-    '    return ' + test.input.value + ';',
-    '  }',
-    '});'
-  ]);
-};
-
-wrap.js.output = function(test) {
-  return joinLines([
-    '__doctest.enqueue({',
-    '  type: "output",',
-    '  ":": ' + test.output.loc.start.line + ',',
-    '  "!": ' + test['!'] + ',',
-    '  thunk: function() {',
-    '    return ' + test.output.value + ';',
-    '  }',
-    '});'
-  ]);
-};
-
-wrap.coffee = wrap('coffee');
-
-wrap.coffee.input = function(test) {
-  return joinLines([
+function wrap$coffee(test) {
+  return [
     '__doctest.enqueue {',
     '  type: "input"',
     '  thunk: ->',
     indentN(4, test.input.value),
     '}'
-  ]);
-};
-
-wrap.coffee.output = function(test) {
-  return joinLines([
+  ].concat(test.output == null ? [] : [
     '__doctest.enqueue {',
     '  type: "output"',
     '  ":": ' + test.output.loc.start.line,
@@ -375,10 +296,10 @@ wrap.coffee.output = function(test) {
     '  thunk: ->',
     indentN(4, test.output.value),
     '}'
-  ]);
-};
+  ]).join('\n');
+}
 
-rewrite.js = function(prefix, input) {
+function rewrite$js(prefix, input) {
   //  1. Locate block comments and line comments within the input text.
   //
   //  2. Create a list of comment chunks from the list of line comments
@@ -397,7 +318,7 @@ rewrite.js = function(prefix, input) {
   //  4. Map each comment chunk in the list produced by step 2 to a
   //     string of JavaScript code derived from the chunk's doctests.
   //
-  //  5. Zip the lists produced by steps 3 and 4; flatten; and join.
+  //  5. Zip the lists produced by steps 3 and 4.
   //
   //  6. Find block comments in the source code produced by step 5.
   //     (The locations of block comments located in step 1 are not
@@ -406,117 +327,114 @@ rewrite.js = function(prefix, input) {
   //  7. Repeat steps 3 through 5 for the list of block comments
   //     produced by step 6 (substituting "step 6" for "step 2").
 
-  var getComments =
-  R.pipe(R.partialRight(esprima.parse, [{comment: true, loc: true}]),
-         R.prop('comments'));
+  function getComments(input) {
+    return esprima.parse(input, {comment: true, loc: true}).comments;
+  }
 
-  //  tests :: { blockTests :: Array Test, lineTests :: Array Test }
-  var tests = R.pipe(
-    getComments,
-    R.partition(R.propEq('type', 'Block')),
-    R.map(transformComments(prefix)),
-    R.zipObj(['blockTests', 'lineTests'])
-  )(input);
+  //  comments :: { Block :: Array Comment, Line :: Array Comment }
+  var comments = getComments(input).reduce(function(comments, comment) {
+    comments[comment.type].push(comment);
+    return comments;
+  }, {Block: [], Line: []});
+
+  var blockTests = transformComments(prefix, comments.Block);
+  var lineTests = transformComments(prefix, comments.Line);
+
+  var chunks = lineTests
+    .concat([{input: bookend}])
+    .reduce(function(accum, test) {
+      accum.chunks.push(substring(input, accum.loc, test.input.loc.start));
+      accum.loc = (test.output == null ? test.input : test.output).loc.end;
+      return accum;
+    }, {chunks: [], loc: {line: 1, column: 0}})
+    .chunks;
 
   //  source :: String
-  var source = R.pipe(
-    R.append({input: bookend}),
-    reduce([[], {line: 1, column: 0}], function(accum, test) {
-      return [
-        appendTo(accum[0], substring(input, accum[1], test.input.loc.start)),
-        R.defaultTo(test.input, test.output).loc.end
-      ];
-    }),
-    R.head,
-    R.zip(_, R.append('', R.map(wrap.js, tests.lineTests))),
-    R.flatten,
-    R.join('')
-  )(tests.lineTests);
+  var source = lineTests
+    .map(wrap$js)
+    .concat([''])
+    .reduce(function(accum, s, idx) { return accum + chunks[idx] + s; }, '');
 
-  return R.pipe(
-    getComments,
-    R.filter(R.propEq('type', 'Block')),
-    R.append(bookend),
-    reduce([[], {line: 1, column: 0}], function(accum, comment, idx) {
-      return R.pipe(
-        R.filter(R.propEq('commentIndex', idx)),
-        R.map(wrap.js),
-        joinLines,
-        appendTo(R.append(substring(source, accum[1], comment.loc.start),
-                          accum[0])),
-        R.of,
-        R.append(comment.loc.end)
-      )(tests.blockTests);
-    }),
-    R.head,
-    R.join('')
-  )(source);
-};
+  return getComments(source)
+    .filter(function(comment) { return comment.type === 'Block'; })
+    .concat([bookend])
+    .reduce(function(accum, comment, idx) {
+      accum.chunks.push(
+        substring(source, accum.loc, comment.loc.start),
+        blockTests
+          .filter(function(test) { return test.commentIndex === idx; })
+          .map(wrap$js)
+          .join('\n')
+      );
+      accum.loc = comment.loc.end;
+      return accum;
+    }, {chunks: [], loc: {line: 1, column: 0}})
+    .chunks
+    .join('');
+}
 
-rewrite.coffee = function(prefix, input) {
-  var chunks = R.pipe(
-    R.match(/^.*(?=\n)/gm),
-    R.addIndex(R.reduce)(function(accum, line, idx) {
-      var literalChunks = accum[0];
-      var commentChunks = accum[1];
-      var inCommentChunk = accum[2];
-      var isComment = R.test(/^[ \t]*#(?!##)/, line);
-      var current = isComment ? commentChunks : literalChunks;
-      if (isComment === inCommentChunk) {
-        current[current.length - 1].lines.push(line);
-      } else {
-        current[current.length] = {
-          lines: [line],
-          loc: {start: {line: idx + 1}}
-        };
-      }
-      return [literalChunks, commentChunks, isComment];
-    }, [[{lines: [], loc: {start: {line: 1}}}], [], false]),
-    R.zipObj(['literalChunks', 'commentChunks'])
-  )(input);
+function rewrite$coffee(prefix, input) {
+  var chunks = input.match(/^.*(?=\n)/gm).reduce(function(accum, line, idx) {
+    var isComment = /^[ \t]*#(?!##)/.test(line);
+    var current = isComment ? accum.commentChunks : accum.literalChunks;
+    if (isComment === accum.isComment) {
+      current[current.length - 1].lines.push(line);
+    } else {
+      current.push({lines: [line], loc: {start: {line: idx + 1}}});
+    }
+    accum.isComment = isComment;
+    return accum;
+  }, {
+    literalChunks: [{lines: [], loc: {start: {line: 1}}}],
+    commentChunks: [],
+    isComment: false
+  });
 
-  var matchFullLine = R.match(/^([ \t]*)#[ \t]*(.*)$/);
-  var testChunks = R.map(R.pipe(
-    function(commentChunk) {
-      return R.pipe(
-        R.prop('lines'),
-        reduce(['default', []], function(accum, line, idx) {
-          var state = accum[0];
-          var tests = accum[1];
-          var fullMatch = matchFullLine(line);
-          var indent = fullMatch[1];
-          var match = matchLine(prefix, fullMatch[2]);
-          if (match == null) {
-            return accum;
-          } else if (match[1] === '>') {
-            tests[tests.length] = {indent: indent, input: {value: match[2]}};
-            return ['input', tests];
-          } else if (match[1]) {
-            tests[tests.length - 1][state].value += '\n' + match[2];
-            return [state, tests];
-          } else if (state === 'input') {
-            tests[tests.length - 1].output = {
-              loc: {start: {line: commentChunk.loc.start.line + idx}},
-              value: match[2]
-            };
-            return ['output', tests];
+  var testChunks = chunks.commentChunks.map(function(commentChunk) {
+    var result = commentChunk.lines.reduce(function(accum, line, idx) {
+      var fullMatch = line.match(/^([ \t]*)#[ \t]*(.*)$/);
+      var indent = fullMatch[1];
+      var match = matchLine(prefix, fullMatch[2]);
+      if (match != null) {
+        var $1 = match[1];
+        var $2 = match[2];
+        if ($1 === '>') {
+          accum.state = INPUT;
+          accum.tests.push({indent: indent, input: {value: $2}});
+        } else if ($1 !== '' || accum.state === INPUT) {
+          var last = accum.tests[accum.tests.length - 1];
+          if ($1 !== '') {
+            last[accum.state].value += '\n' + $2;
           } else {
-            return ['default', tests];
+            accum.state = OUTPUT;
+            last[accum.state] = {
+              value: $2,
+              loc: {start: {line: commentChunk.loc.start.line + idx}}
+            };
           }
-        })
-      )(commentChunk);
-    },
-    R.last,
-    R.map(normalizeTest),
-    R.map(R.lift(indentN)(R.path(['indent', 'length']), wrap.coffee)),
-    joinLines
-  ), chunks.commentChunks);
+        } else {
+          accum.state = DEFAULT;
+        }
+      }
+      return accum;
+    }, {state: DEFAULT, tests: []});
 
-  return CoffeeScript.compile(joinLines(R.flatten(R.zip(
-    R.map(R.compose(joinLines, R.prop('lines')), chunks.literalChunks),
-    R.append('', testChunks)
-  ))));
-};
+    return result.tests.map(function($test) {
+      normalizeTest($test);
+      return indentN($test.indent.length, wrap$coffee($test));
+    });
+  });
+
+  function append(s, line) { return s + line + '\n'; }
+  return CoffeeScript.compile(
+    chunks.literalChunks.reduce(function(s, chunk, idx) {
+      return (testChunks[idx] || []).reduce(
+        append,
+        chunk.lines.reduce(append, s)
+      );
+    }, '')
+  );
+}
 
 function functionEval(source) {
   //  Functions created via the Function function are always run in the
@@ -544,58 +462,56 @@ function commonjsEval(source, path) {
   return run(queue);
 }
 
-//  formatError :: Boolean -> Error -> String
-function formatError(includeMessage) {
-  return includeMessage ?
-    function(err) { return '! ' + err.name + ': ' + err.message; } :
-    function(err) { return '! ' + err.name; };
-}
-
 function run(queue) {
-  var results = [];
-  var thunks = [];  // thunks :: Maybe (() -> Undefined)
-  R.forEach(function(io) {
-    if (io.type === 'input') {
-      R.forEach(R.call, thunks);
-      thunks = [io.thunk];
-    } else if (io.type === 'output') {
-      var actual;
-      var throws = false;
+  return queue.reduce(function(accum, io) {
+    var thunk = accum.thunk;
+    if (io.type === INPUT) {
+      if (thunk != null) thunk();
+      accum.thunk = io.thunk;
+    } else if (io.type === OUTPUT) {
+      var either;
       try {
-        actual = R.head(R.map(R.call, thunks));
+        either = {tag: 'Right', value: thunk()};
       } catch (err) {
-        actual = err;
-        throws = true;
+        either = {tag: 'Left', value: err};
       }
+      accum.thunk = null;
       var expected = io.thunk();
 
-      results.push([
-        throws === io['!'] &&
-        (throws ?
-           type(actual) === 'Error' &&
-           actual.name === expected.name &&
-           (expected.message === '' || actual.message === expected.message) :
-         // else
-           Z.equals(actual, expected)),
-        (throws ? formatError(expected.message !== '') : show)(actual),
-        (io['!'] ? formatError(expected.message !== '') : show)(expected),
+      var pass, repr;
+      if (either.tag === 'Left') {
+        var name = either.value.name;
+        var message = either.value.message;
+        pass = io['!'] &&
+               name === expected.name &&
+               message === expected.message.replace(/^$/, message);
+        repr = '! ' + name + message.replace(/^(?!$)/, ': ');
+      } else {
+        pass = !io['!'] && Z.equals(either.value, expected);
+        repr = show(either.value);
+      }
+
+      accum.results.push([
+        pass,
+        repr,
+        io['!'] ?
+          '! ' + expected.name + expected.message.replace(/^(?!$)/, ': ') :
+          show(expected),
         io[':']
       ]);
-      thunks = [];
     }
-  }, queue);
-  return results;
+    return accum;
+  }, {results: [], thunk: null}).results;
 }
 
 function log(results) {
-  console.log(R.join('',
-                     R.map(R.ifElse(R.head, R.always('.'), R.always('x')),
-                           results)));
-  R.forEach(
-    R.apply(function(pass, actual, expected, num) {
-      console.log('FAIL: expected ' + expected + ' on line ' + num +
-                  ' (got ' + actual + ')');
-    }),
-    R.reject(R.head, results)
-  );
+  console.log(results.reduce(function(s, tuple) {
+    return s + (tuple[0] ? '.' : 'x');
+  }, ''));
+  results.forEach(function(tuple) {
+    if (!tuple[0]) {
+      console.log('FAIL: expected ' + tuple[2] + ' on line ' + tuple[3] +
+                  ' (got ' + tuple[1] + ')');
+    }
+  });
 }

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
     "coffee-script": "1.10.x",
     "commander": "2.8.x",
     "esprima": "3.1.x",
-    "ramda": "0.19.x",
-    "sanctuary-type-classes": "4.0.x",
-    "sanctuary-type-identifiers": "1.0.x"
+    "sanctuary-type-classes": "8.1.x"
   },
   "devDependencies": {
     "eslint": "4.9.x",

--- a/test/index.js
+++ b/test/index.js
@@ -2,13 +2,15 @@
 
 var execSync = require('child_process').execSync;
 
-var R = require('ramda');
+var Z = require('sanctuary-type-classes');
 
 var doctest = require('..');
 
 
 //  unlines :: Array String -> String
-var unlines = R.compose(R.join(''), R.map(R.concat(R.__, '\n')));
+function unlines(lines) {
+  return lines.reduce(function(s, line) { return s + line + '\n'; }, '');
+}
 
 
 var gray  = '';
@@ -26,7 +28,7 @@ if (!process.env.NODE_DISABLE_COLORS && process.platform !== 'win32') {
 var failures = 0;
 
 function printResult(actual, expected, message) {
-  if (R.equals(actual, expected)) {
+  if (Z.equals(actual, expected)) {
     return console.log(green + ' \u2714 ' + gray + ' ' + message + reset);
   } else {
     failures += 1;


### PR DESCRIPTION
This pull request excites me for several reasons:

  - it removes a dependency;
  - it removes more code than it adds; and
  - it dramatically improves performance.

Initially this project depended on [`_.isEqual`][1]. Back in #49 we switched to the Ramda equivalent, then known as [`R.eqDeep`][2], now known as [`R.equals`][3]. We currently depend on sanctuary-type-classes so we can use [`Z.equals`][4] instead.

I replaced uses of Ramda functions with uses of built-in methods where applicable (`Array#reduce` in place of `R.reduce`, for example). In the process, I also significantly simplified several algorithms (the `substring` function provides a striking example). The results are impressive: on my computer, running `node_modules/.bin/doctest --module commonjs --prefix . -- index.js` for [Sanctuary][5] takes less than two seconds to complete after applying these changes compared with more than *forty* seconds.

@Avaq, this demonstrates that I *do* start to care about performance at some point. ;)


[1]: http://underscorejs.org/#isEqual
[2]: http://ramdajs.com/0.10/docs/#eqDeep
[3]: http://ramdajs.com/docs/#equals
[4]: https://github.com/sanctuary-js/sanctuary-type-classes#equals
[5]: https://github.com/sanctuary-js/sanctuary
