### PR TITLE
simplify formatting of error messages

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -26,12 +26,12 @@ var errors = [];
 if (program.module != null &&
     program.module !== 'amd' &&
     program.module !== 'commonjs') {
-  errors.push('invalid module `' + program.module + "'");
+  errors.push('Invalid module `' + program.module + "'");
 }
 if (program.type != null &&
     program.type !== 'coffee' &&
     program.type !== 'js') {
-  errors.push('invalid type `' + program.type + "'");
+  errors.push('Invalid type `' + program.type + "'");
 }
 if (errors.length > 0) {
   process.stderr.write(formatErrors(errors));
@@ -43,8 +43,7 @@ process.exit(program.args.reduce(function(status, path) {
   try {
     results = doctest(path, program);
   } catch (err) {
-    var msg = err.message;
-    process.stderr.write(formatErrors([msg[0].toLowerCase() + msg.slice(1)]));
+    process.stderr.write(formatErrors([err.message]));
     process.exit(1);
   }
   return results.reduce(function(status, tuple) {

--- a/test/index.js
+++ b/test/index.js
@@ -102,7 +102,7 @@ testCommand('bin/doctest --type xxx', {
   stdout: '',
   stderr: unlines([
     '',
-    "  error: invalid type `xxx'",
+    "  error: Invalid type `xxx'",
     ''
   ])
 });
@@ -167,7 +167,7 @@ testCommand('bin/doctest test/bin/executable', {
   stdout: '',
   stderr: unlines([
     '',
-    '  error: cannot infer type from extension',
+    '  error: Cannot infer type from extension',
     ''
   ])
 });


### PR DESCRIPTION
Years ago I chose to use `String#toLowerCase` to match the format of [Commander.js][1] error messages. This was unwise, as I recently discovered when doctest misreported an error as `sum is not defined` rather than `Sum is not defined`, while testing a module containing both `sum` and `Sum`. Confusing!


[1]: https://github.com/tj/commander.js
