### PR TITLE
coffeescript@1.10.x

### DIFF
--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -13,7 +13,7 @@
 var fs = require('fs');
 var pathlib = require('path');
 
-var CoffeeScript = require('coffee-script');
+var CoffeeScript = require('coffeescript');
 var esprima = require('esprima');
 var Z = require('sanctuary-type-classes');
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git://github.com/davidchambers/doctest.git"
   },
   "dependencies": {
-    "coffee-script": "1.10.x",
+    "coffeescript": "1.10.x",
     "commander": "2.8.x",
     "esprima": "3.1.x",
     "sanctuary-type-classes": "8.1.x"


### PR DESCRIPTION
<https://www.npmjs.com/package/coffee-script>:

> # This package has been deprecated
>
> Author message:
>
> `CoffeeScript on NPM has moved to "coffeescript" (no hyphen)`
