### PR TITLE
use sanctuary-show for string representations

### DIFF
--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -15,6 +15,7 @@ var pathlib = require('path');
 
 var CoffeeScript = require('coffeescript');
 var esprima = require('esprima');
+var _show = require('sanctuary-show');
 var Z = require('sanctuary-type-classes');
 
 
@@ -90,7 +91,7 @@ function quote(s) {
 function show(x) {
   return Object.prototype.toString.call(x) === '[object Error]' ?
     String(x) :
-    Z.toString(x);
+    _show(x);
 }
 
 //  unlines :: Array String -> String

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "coffeescript": "1.10.x",
     "commander": "2.8.x",
     "esprima": "4.0.x",
+    "sanctuary-show": "1.0.x",
     "sanctuary-type-classes": "8.1.x"
   },
   "devDependencies": {

--- a/test/fantasy-land/index.js
+++ b/test/fantasy-land/index.js
@@ -7,8 +7,8 @@ function Absolute(n) {
 
 Absolute['@@type'] = 'doctest/Absolute';
 
-Absolute.prototype.toString = function() {
-  return 'Absolute(' + this.value + ')';
+Absolute.prototype['@@show'] = function() {
+  return 'Absolute (' + this.value + ')';
 };
 
 Absolute.prototype['fantasy-land/equals'] = function(other) {

--- a/test/fantasy-land/results.json
+++ b/test/fantasy-land/results.json
@@ -3,8 +3,8 @@
     "uses Z.equals for equality checks",
     [
       true,
-      "Absolute(-1)",
-      "Absolute(1)",
+      "Absolute (-1)",
+      "Absolute (1)",
       2
     ]
   ]


### PR DESCRIPTION
[`show`][1] replaces [`Z.toString`][2]. Switching will make doctest compatible with Sanctuary's various algebraic data types, which will soon define `@@show` but not `toString`.


[1]: https://github.com/sanctuary-js/sanctuary-show#show
[2]: https://github.com/sanctuary-js/sanctuary-type-classes/tree/v8.1.1#toString
