### PR TITLE
commander@2.19.x

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -17,9 +17,9 @@ program
 .option('-t, --type <type>', 'specify file type ("coffee" or "js")')
 .parse(process.argv);
 
-//  formatErrors :: NonEmpty (Array String) -> String
+//  formatErrors :: Array String -> String
 function formatErrors(errors) {
-  return [''].concat(errors).join('\n  error: ') + '\n\n';
+  return errors.map(function(s) { return 'error: ' + s + '\n'; }).join('');
 }
 
 var errors = [];

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "coffeescript": "1.12.x",
-    "commander": "2.8.x",
+    "commander": "2.19.x",
     "esprima": "4.0.x",
     "sanctuary-show": "1.0.x",
     "sanctuary-type-classes": "9.0.x"

--- a/test/index.js
+++ b/test/index.js
@@ -94,9 +94,7 @@ testCommand('bin/doctest --xxx', {
   status: 1,
   stdout: '',
   stderr: unlines([
-    '',
-    "  error: unknown option `--xxx'",
-    ''
+    "error: unknown option `--xxx'"
   ])
 });
 
@@ -104,9 +102,7 @@ testCommand('bin/doctest --type', {
   status: 1,
   stdout: '',
   stderr: unlines([
-    '',
-    "  error: option `-t, --type <type>' argument missing",
-    ''
+    "error: option `-t, --type <type>' argument missing"
   ])
 });
 
@@ -114,9 +110,7 @@ testCommand('bin/doctest --type xxx', {
   status: 1,
   stdout: '',
   stderr: unlines([
-    '',
-    "  error: Invalid type `xxx'",
-    ''
+    "error: Invalid type `xxx'"
   ])
 });
 
@@ -179,9 +173,7 @@ testCommand('bin/doctest test/bin/executable', {
   status: 1,
   stdout: '',
   stderr: unlines([
-    '',
-    '  error: Cannot infer type from extension',
-    ''
+    'error: Cannot infer type from extension'
   ])
 });
 


### PR DESCRIPTION
<https://github.com/tj/commander.js/releases>

The formatting of [Commander.js][1] error messages has changed; I updated `formatErrors` to match.


[1]: https://github.com/tj/commander.js
