### PR TITLE
sanctuary-scripts@2.0.x

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1,52 +1,58 @@
 'use strict';
 
-var program = require('commander');
+var program = require ('commander');
 
-var doctest = require('..');
-var pkg = require('../package.json');
+var doctest = require ('..');
+var pkg = require ('../package.json');
 
 
 program
-.version(pkg.version)
-.usage('[options] path/to/js/or/coffee/module')
-.option('-m, --module <type>', 'specify module system ("amd" or "commonjs")')
-.option('    --nodejs <options>', 'pass options directly to the "node" binary')
-.option('    --prefix <prefix>', 'specify Transcribe-style prefix (e.g. ".")')
-.option('-p, --print', 'output the rewritten source without running tests')
-.option('-s, --silent', 'suppress output')
-.option('-t, --type <type>', 'specify file type ("coffee" or "js")')
-.parse(process.argv);
+.version (pkg.version)
+.usage ('[options] path/to/js/or/coffee/module')
+.option ('-m, --module <type>',
+         'specify module system ("amd" or "commonjs")')
+.option ('    --nodejs <options>',
+         'pass options directly to the "node" binary')
+.option ('    --prefix <prefix>',
+         'specify Transcribe-style prefix (e.g. ".")')
+.option ('-p, --print',
+         'output the rewritten source without running tests')
+.option ('-s, --silent',
+         'suppress output')
+.option ('-t, --type <type>',
+         'specify file type ("coffee" or "js")')
+.parse (process.argv);
 
 //  formatErrors :: Array String -> String
 function formatErrors(errors) {
-  return errors.map(function(s) { return 'error: ' + s + '\n'; }).join('');
+  return (errors.map (function(s) { return 'error: ' + s + '\n'; })).join ('');
 }
 
 var errors = [];
 if (program.module != null &&
     program.module !== 'amd' &&
     program.module !== 'commonjs') {
-  errors.push('Invalid module `' + program.module + "'");
+  errors.push ('Invalid module `' + program.module + "'");
 }
 if (program.type != null &&
     program.type !== 'coffee' &&
     program.type !== 'js') {
-  errors.push('Invalid type `' + program.type + "'");
+  errors.push ('Invalid type `' + program.type + "'");
 }
 if (errors.length > 0) {
-  process.stderr.write(formatErrors(errors));
-  process.exit(1);
+  process.stderr.write (formatErrors (errors));
+  process.exit (1);
 }
 
-process.exit(program.args.reduce(function(status, path) {
+process.exit (program.args.reduce (function(status, path) {
   var results;
   try {
-    results = doctest(path, program);
+    results = doctest (path, program);
   } catch (err) {
-    process.stderr.write(formatErrors([err.message]));
-    process.exit(1);
+    process.stderr.write (formatErrors ([err.message]));
+    process.exit (1);
   }
-  return results.reduce(function(status, tuple) {
+  return results.reduce (function(status, tuple) {
     return tuple[0] ? status : 1;
   }, status);
 }, 0));

--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -10,20 +10,20 @@
 
 'use strict';
 
-var fs = require('fs');
-var pathlib = require('path');
+var fs = require ('fs');
+var pathlib = require ('path');
 
-var CoffeeScript = require('coffeescript');
-var esprima = require('esprima');
-var _show = require('sanctuary-show');
-var Z = require('sanctuary-type-classes');
+var CoffeeScript = require ('coffeescript');
+var esprima = require ('esprima');
+var _show = require ('sanctuary-show');
+var Z = require ('sanctuary-type-classes');
 
 
 function inferType(path) {
-  switch (pathlib.extname(path)) {
+  switch (pathlib.extname (path)) {
     case '.coffee': return 'coffee';
     case '.js':     return 'js';
-    default:        throw new Error('Cannot infer type from extension');
+    default:        throw new Error ('Cannot infer type from extension');
   }
 }
 
@@ -31,84 +31,84 @@ var rewriters = {coffee: rewrite$coffee, js: rewrite$js};
 
 function evaluate(moduleType, source, path) {
   return moduleType === 'commonjs' ?
-    commonjsEval(source, path) :
-    functionEval(source);
+    commonjsEval (source, path) :
+    functionEval (source);
 }
 
 module.exports = function(path, options) {
   if (options.module != null &&
       options.module !== 'amd' &&
       options.module !== 'commonjs') {
-    throw new Error('Invalid module `' + options.module + "'");
+    throw new Error ('Invalid module `' + options.module + "'");
   }
   if (options.type != null &&
       options.type !== 'coffee' &&
       options.type !== 'js') {
-    throw new Error('Invalid type `' + options.type + "'");
+    throw new Error ('Invalid type `' + options.type + "'");
   }
 
-  var source = toModule(
-    rewriters[options.type == null ? inferType(path) : options.type](
+  var source = toModule (
+    rewriters[options.type == null ? inferType (path) : options.type] (
       options.prefix == null ? '' : options.prefix,
-      fs.readFileSync(path, 'utf8')
-        .replace(/\r\n?/g, '\n')
-        .replace(/^#!.*/, '')
+      fs.readFileSync (path, 'utf8')
+        .replace (/\r\n?/g, '\n')
+        .replace (/^#!.*/, '')
     ),
     options.module
   );
 
   if (options.print) {
-    console.log(source.replace(/\n$/, ''));
+    console.log (source.replace (/\n$/, ''));
     return [];
   } else if (options.silent) {
-    return evaluate(options.module, source, path);
+    return evaluate (options.module, source, path);
   } else {
-    console.log('running doctests in ' + path + '...');
-    var results = evaluate(options.module, source, path);
-    log(results);
+    console.log ('running doctests in ' + path + '...');
+    var results = evaluate (options.module, source, path);
+    log (results);
     return results;
   }
 };
 
 //  indentN :: (Integer, String) -> String
 function indentN(n, s) {
-  return s.replace(/^(?!$)/gm, Array(n + 1).join(' '));
+  return s.replace (/^(?!$)/gm, (Array (n + 1)).join (' '));
 }
 
 //  matchLine :: (String, String) -> Nullable (Array3 String String String)
 function matchLine(prefix, s) {
-  return s.slice(0, prefix.length) === prefix ?
-    s.slice(prefix.length).match(/^\s*(>|[.]*)[ ]?(.*)$/) :
+  return s.slice (0, prefix.length) === prefix ?
+    (s.slice (prefix.length)).match (/^\s*(>|[.]*)[ ]?(.*)$/) :
     null;
 }
 
 //  quote :: String -> String
 function quote(s) {
-  return "'" + s.replace(/'/g, "\\'") + "'";
+  return "'" + s.replace (/'/g, "\\'") + "'";
 }
 
 //  show :: a -> String
 function show(x) {
-  return Object.prototype.toString.call(x) === '[object Error]' ?
-    String(x) :
-    _show(x);
+  return Object.prototype.toString.call (x) === '[object Error]' ?
+    String (x) :
+    _show (x);
 }
 
 //  unlines :: Array String -> String
 function unlines(lines) {
-  return lines.reduce(function(s, line) { return s + line + '\n'; }, '');
+  return lines.reduce (function(s, line) { return s + line + '\n'; }, '');
 }
 
 //  iifeWrap :: String -> String
 function iifeWrap(s) {
-  return 'void function() {\n' + indentN(2, s) + '}.call(this);';
+  return 'void function() {\n' + indentN (2, s) + '}.call(this);';
 }
 
 //  toModule :: (String, String?) -> String
 function toModule(source, moduleType) {
   switch (moduleType) {
     case 'amd':
-      return unlines([
+      return unlines ([
         source,
         'function define() {',
         '  for (var idx = 0; idx < arguments.length; idx += 1) {',
@@ -120,14 +120,14 @@ function toModule(source, moduleType) {
         '}'
       ]);
     case 'commonjs':
-      return iifeWrap(unlines([
+      return iifeWrap (unlines ([
         'var __doctest = {',
         '  require: require,',
         '  queue: [],',
         '  enqueue: function(io) { this.queue.push(io); }',
         '};',
         '',
-        iifeWrap(source),
+        iifeWrap (source),
         '',
         '(module.exports || exports).__doctest = __doctest;'
       ]));
@@ -140,10 +140,10 @@ function toModule(source, moduleType) {
 function normalizeTest($test) {
   var $output = $test.output;
   if ($output != null) {
-    var match = $output.value.match(/^![ ]?([^:]*)(?::[ ]?(.*))?$/);
+    var match = $output.value.match (/^![ ]?([^:]*)(?::[ ]?(.*))?$/);
     $test['!'] = match != null;
     if ($test['!']) {
-      $output.value = 'new ' + match[1] + '(' + quote(match[2] || '') + ')';
+      $output.value = 'new ' + match[1] + '(' + quote (match[2] || '') + ')';
     }
   }
 }
@@ -165,7 +165,7 @@ var DEFAULT = 'default';
 //
 //  Returns the doctests present in the given esprima comment objects.
 //
-//  > transformComments('', [{
+//  > transformComments ('', [{
 //  .   type: 'Line',
 //  .   value: ' > 6 * 7',
 //  .   loc: {start: {line: 1, column: 0}, end: {line: 1, column: 10}}
@@ -185,25 +185,25 @@ var DEFAULT = 'default';
 //  .     loc: {start: {line: 2, column: 0}, end: {line: 2, column: 5}}}
 //  . }]
 function transformComments(prefix, comments) {
-  var result = comments.reduce(function(accum, comment, commentIndex) {
-    return comment.value.split('\n').reduce(function(accum, line, idx) {
+  var result = comments.reduce (function(accum, comment, commentIndex) {
+    return (comment.value.split ('\n')).reduce (function(accum, line, idx) {
       var normalizedLine, start, end;
       if (comment.type === 'Block') {
-        normalizedLine = line.replace(/^\s*[*]?\s*/, '');
+        normalizedLine = line.replace (/^\s*[*]?\s*/, '');
         start = end = {line: comment.loc.start.line + idx};
       } else if (comment.type === 'Line') {
-        normalizedLine = line.replace(/^\s*/, '');
+        normalizedLine = line.replace (/^\s*/, '');
         start = comment.loc.start;
         end = comment.loc.end;
       }
 
-      var match = matchLine(prefix, normalizedLine);
+      var match = matchLine (prefix, normalizedLine);
       if (match != null) {
         var $1 = match[1];
         var $2 = match[2];
         if ($1 === '>') {
           accum.state = INPUT;
-          accum.tests.push({
+          accum.tests.push ({
             commentIndex: commentIndex,
             input: {value: $2, loc: {start: start, end: end}}
           });
@@ -226,7 +226,7 @@ function transformComments(prefix, comments) {
   }, {state: DEFAULT, tests: []});
 
   var $tests = result.tests;
-  $tests.forEach(normalizeTest);
+  $tests.forEach (normalizeTest);
   return $tests;
 }
 
@@ -240,27 +240,27 @@ function transformComments(prefix, comments) {
 //  Positions are specified in terms of line and column rather than index.
 //  {line: 1, column: 0} represents the first character of the first line.
 //
-//  > substring('hello\nworld', {line: 1, column: 3}, {line: 2, column: 2})
+//  > substring ('hello\nworld', {line: 1, column: 3}, {line: 2, column: 2})
 //  'lo\nwo'
-//  > substring('hello\nworld', {line: 1, column: 0}, {line: 1, column: 0})
+//  > substring ('hello\nworld', {line: 1, column: 0}, {line: 1, column: 0})
 //  ''
 function substring(input, start, end) {
-  var lines = input.split(/^/m);
+  var lines = input.split (/^/m);
   return (
     start.line === end.line ?
-      lines[start.line - 1].slice(start.column, end.column) :
+      lines[start.line - 1].slice (start.column, end.column) :
     end.line === Infinity ?
-      lines[start.line - 1].slice(start.column) +
-      lines.slice(start.line).join('') :
+      lines[start.line - 1].slice (start.column) +
+      (lines.slice (start.line)).join ('') :
     // else
-      lines[start.line - 1].slice(start.column) +
-      lines.slice(start.line, end.line - 1).join('') +
-      lines[end.line - 1].slice(0, end.column)
+      lines[start.line - 1].slice (start.column) +
+      (lines.slice (start.line, end.line - 1)).join ('') +
+      lines[end.line - 1].slice (0, end.column)
   );
 }
 
 function wrap$js(test) {
-  var type = esprima.parse(test.input.value).body[0].type;
+  var type = (esprima.parse (test.input.value)).body[0].type;
   return type === 'FunctionDeclaration' || type === 'VariableDeclaration' ?
     test.input.value :
     [
@@ -270,7 +270,7 @@ function wrap$js(test) {
       '    return ' + test.input.value + ';',
       '  }',
       '});'
-    ].concat(test.output == null ? [] : [
+    ].concat (test.output == null ? [] : [
       '__doctest.enqueue({',
       '  type: "output",',
       '  ":": ' + test.output.loc.start.line + ',',
@@ -279,7 +279,7 @@ function wrap$js(test) {
       '    return ' + test.output.value + ';',
       '  }',
       '});'
-    ]).join('\n');
+    ]).join ('\n');
 }
 
 function wrap$coffee(test) {
@@ -287,17 +287,17 @@ function wrap$coffee(test) {
     '__doctest.enqueue {',
     '  type: "input"',
     '  thunk: ->',
-    indentN(4, test.input.value),
+    indentN (4, test.input.value),
     '}'
-  ].concat(test.output == null ? [] : [
+  ].concat (test.output == null ? [] : [
     '__doctest.enqueue {',
     '  type: "output"',
     '  ":": ' + test.output.loc.start.line,
     '  "!": ' + test['!'],
     '  thunk: ->',
-    indentN(4, test.output.value),
+    indentN (4, test.output.value),
     '}'
-  ]).join('\n');
+  ]).join ('\n');
 }
 
 function rewrite$js(prefix, input) {
@@ -329,22 +329,22 @@ function rewrite$js(prefix, input) {
   //     produced by step 6 (substituting "step 6" for "step 2").
 
   function getComments(input) {
-    return esprima.parse(input, {comment: true, loc: true}).comments;
+    return (esprima.parse (input, {comment: true, loc: true})).comments;
   }
 
   //  comments :: { Block :: Array Comment, Line :: Array Comment }
-  var comments = getComments(input).reduce(function(comments, comment) {
-    comments[comment.type].push(comment);
+  var comments = (getComments (input)).reduce (function(comments, comment) {
+    comments[comment.type].push (comment);
     return comments;
   }, {Block: [], Line: []});
 
-  var blockTests = transformComments(prefix, comments.Block);
-  var lineTests = transformComments(prefix, comments.Line);
+  var blockTests = transformComments (prefix, comments.Block);
+  var lineTests = transformComments (prefix, comments.Line);
 
   var chunks = lineTests
-    .concat([{input: bookend}])
-    .reduce(function(accum, test) {
-      accum.chunks.push(substring(input, accum.loc, test.input.loc.start));
+    .concat ([{input: bookend}])
+    .reduce (function(accum, test) {
+      accum.chunks.push (substring (input, accum.loc, test.input.loc.start));
       accum.loc = (test.output == null ? test.input : test.output).loc.end;
       return accum;
     }, {chunks: [], loc: {line: 1, column: 0}})
@@ -352,36 +352,37 @@ function rewrite$js(prefix, input) {
 
   //  source :: String
   var source = lineTests
-    .map(wrap$js)
-    .concat([''])
-    .reduce(function(accum, s, idx) { return accum + chunks[idx] + s; }, '');
+    .map (wrap$js)
+    .concat ([''])
+    .reduce (function(accum, s, idx) { return accum + chunks[idx] + s; }, '');
 
-  return getComments(source)
-    .filter(function(comment) { return comment.type === 'Block'; })
-    .concat([bookend])
-    .reduce(function(accum, comment, idx) {
-      accum.chunks.push(
-        substring(source, accum.loc, comment.loc.start),
+  return getComments (source)
+    .filter (function(comment) { return comment.type === 'Block'; })
+    .concat ([bookend])
+    .reduce (function(accum, comment, idx) {
+      accum.chunks.push (
+        substring (source, accum.loc, comment.loc.start),
         blockTests
-          .filter(function(test) { return test.commentIndex === idx; })
-          .map(wrap$js)
-          .join('\n')
+          .filter (function(test) { return test.commentIndex === idx; })
+          .map (wrap$js)
+          .join ('\n')
       );
       accum.loc = comment.loc.end;
       return accum;
     }, {chunks: [], loc: {line: 1, column: 0}})
     .chunks
-    .join('');
+    .join ('');
 }
 
 function rewrite$coffee(prefix, input) {
-  var chunks = input.match(/^.*(?=\n)/gm).reduce(function(accum, line, idx) {
-    var isComment = /^[ \t]*#(?!##)/.test(line);
+  var lines = input.match (/^.*(?=\n)/gm);
+  var chunks = lines.reduce (function(accum, line, idx) {
+    var isComment = /^[ \t]*#(?!##)/.test (line);
     var current = isComment ? accum.commentChunks : accum.literalChunks;
     if (isComment === accum.isComment) {
-      current[current.length - 1].lines.push(line);
+      current[current.length - 1].lines.push (line);
     } else {
-      current.push({lines: [line], loc: {start: {line: idx + 1}}});
+      current.push ({lines: [line], loc: {start: {line: idx + 1}}});
     }
     accum.isComment = isComment;
     return accum;
@@ -391,17 +392,17 @@ function rewrite$coffee(prefix, input) {
     isComment: false
   });
 
-  var testChunks = chunks.commentChunks.map(function(commentChunk) {
-    var result = commentChunk.lines.reduce(function(accum, line, idx) {
-      var fullMatch = line.match(/^([ \t]*)#[ \t]*(.*)$/);
+  var testChunks = chunks.commentChunks.map (function(commentChunk) {
+    var result = commentChunk.lines.reduce (function(accum, line, idx) {
+      var fullMatch = line.match (/^([ \t]*)#[ \t]*(.*)$/);
       var indent = fullMatch[1];
-      var match = matchLine(prefix, fullMatch[2]);
+      var match = matchLine (prefix, fullMatch[2]);
       if (match != null) {
         var $1 = match[1];
         var $2 = match[2];
         if ($1 === '>') {
           accum.state = INPUT;
-          accum.tests.push({indent: indent, input: {value: $2}});
+          accum.tests.push ({indent: indent, input: {value: $2}});
         } else if ($1 !== '' || accum.state === INPUT) {
           var last = accum.tests[accum.tests.length - 1];
           if ($1 !== '') {
@@ -420,18 +421,18 @@ function rewrite$coffee(prefix, input) {
       return accum;
     }, {state: DEFAULT, tests: []});
 
-    return result.tests.map(function($test) {
-      normalizeTest($test);
-      return indentN($test.indent.length, wrap$coffee($test));
+    return result.tests.map (function($test) {
+      normalizeTest ($test);
+      return indentN ($test.indent.length, wrap$coffee ($test));
     });
   });
 
   function append(s, line) { return s + line + '\n'; }
-  return CoffeeScript.compile(
-    chunks.literalChunks.reduce(function(s, chunk, idx) {
-      return (testChunks[idx] || []).reduce(
+  return CoffeeScript.compile (
+    chunks.literalChunks.reduce (function(s, chunk, idx) {
+      return (testChunks[idx] || []).reduce (
         append,
-        chunk.lines.reduce(append, s)
+        chunk.lines.reduce (append, s)
       );
     }, '')
   );
@@ -443,41 +444,41 @@ function functionEval(source) {
   //  in _this_ context.
   //
   //  The `evaluate` function takes one argument, named `__doctest`.
-  var evaluate = Function('__doctest', source);
+  var evaluate = Function ('__doctest', source);
   var queue = [];
-  evaluate({enqueue: function(io) { queue.push(io); }});
-  return run(queue);
+  evaluate ({enqueue: function(io) { queue.push (io); }});
+  return run (queue);
 }
 
 function commonjsEval(source, path) {
   var abspath =
-  pathlib.resolve(path).replace(/[.][^.]+$/, '-' + Date.now() + '.js');
+  (pathlib.resolve (path)).replace (/[.][^.]+$/, '-' + Date.now () + '.js');
 
-  fs.writeFileSync(abspath, source);
+  fs.writeFileSync (abspath, source);
   var queue;
   try {
-    queue = require(abspath).__doctest.queue;
+    queue = (require (abspath)).__doctest.queue;
   } finally {
-    fs.unlinkSync(abspath);
+    fs.unlinkSync (abspath);
   }
-  return run(queue);
+  return run (queue);
 }
 
 function run(queue) {
-  return queue.reduce(function(accum, io) {
+  return queue.reduce (function(accum, io) {
     var thunk = accum.thunk;
     if (io.type === INPUT) {
-      if (thunk != null) thunk();
+      if (thunk != null) thunk ();
       accum.thunk = io.thunk;
     } else if (io.type === OUTPUT) {
       var either;
       try {
-        either = {tag: 'Right', value: thunk()};
+        either = {tag: 'Right', value: thunk ()};
       } catch (err) {
         either = {tag: 'Left', value: err};
       }
       accum.thunk = null;
-      var expected = io.thunk();
+      var expected = io.thunk ();
 
       var pass, repr;
       if (either.tag === 'Left') {
@@ -485,20 +486,20 @@ function run(queue) {
         var message = either.value.message;
         pass = io['!'] &&
                name === expected.name &&
-               message === expected.message.replace(/^$/, message);
+               message === expected.message.replace (/^$/, message);
         repr = '! ' + name +
-               (expected.message && message.replace(/^(?!$)/, ': '));
+               (expected.message && message.replace (/^(?!$)/, ': '));
       } else {
-        pass = !io['!'] && Z.equals(either.value, expected);
-        repr = show(either.value);
+        pass = !io['!'] && Z.equals (either.value, expected);
+        repr = show (either.value);
       }
 
-      accum.results.push([
+      accum.results.push ([
         pass,
         repr,
         io['!'] ?
-          '! ' + expected.name + expected.message.replace(/^(?!$)/, ': ') :
-          show(expected),
+          '! ' + expected.name + expected.message.replace (/^(?!$)/, ': ') :
+          show (expected),
         io[':']
       ]);
     }
@@ -507,13 +508,13 @@ function run(queue) {
 }
 
 function log(results) {
-  console.log(results.reduce(function(s, tuple) {
+  console.log (results.reduce (function(s, tuple) {
     return s + (tuple[0] ? '.' : 'x');
   }, ''));
-  results.forEach(function(tuple) {
+  results.forEach (function(tuple) {
     if (!tuple[0]) {
-      console.log('FAIL: expected ' + tuple[2] + ' on line ' + tuple[3] +
-                  ' (got ' + tuple[1] + ')');
+      console.log ('FAIL: expected ' + tuple[2] + ' on line ' + tuple[3] +
+                   ' (got ' + tuple[1] + ')');
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "sanctuary-type-classes": "10.0.x"
   },
   "devDependencies": {
-    "sanctuary-scripts": "1.6.x"
+    "sanctuary-scripts": "2.0.x"
   },
   "scripts": {
     "doctest": "sanctuary-doctest",

--- a/test/index.js
+++ b/test/index.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var execSync = require('child_process').execSync;
-var pathlib = require('path');
+var execSync = (require ('child_process')).execSync;
+var pathlib = require ('path');
 
-var Z = require('sanctuary-type-classes');
+var Z = require ('sanctuary-type-classes');
 
-var doctest = require('..');
+var doctest = require ('..');
 
 
 //  unlines :: Array String -> String
 function unlines(lines) {
-  return lines.reduce(function(s, line) { return s + line + '\n'; }, '');
+  return lines.reduce (function(s, line) { return s + line + '\n'; }, '');
 }
 
 
@@ -29,25 +29,25 @@ if (!process.env.NODE_DISABLE_COLORS && process.platform !== 'win32') {
 var failures = 0;
 
 function printResult(actual, expected, message) {
-  if (Z.equals(actual, expected)) {
-    return console.log(green + ' \u2714 ' + gray + ' ' + message + reset);
+  if (Z.equals (actual, expected)) {
+    return console.log (green + ' \u2714 ' + gray + ' ' + message + reset);
   } else {
     failures += 1;
-    console.warn(red + ' \u2718 ' + gray + ' ' + message + reset);
-    console.log(gray + '      expected: ' + green + expected + reset);
-    return console.log(gray + '      received: ' + red + actual + reset);
+    console.warn (red + ' \u2718 ' + gray + ' ' + message + reset);
+    console.log (gray + '      expected: ' + green + expected + reset);
+    return console.log (gray + '      received: ' + red + actual + reset);
   }
 }
 
 
 function testModule(path, options) {
-  var type = path.split('.').pop();
-  var actuals = doctest(path, options);
-  var expecteds = require(pathlib.resolve(path, '..', 'results.json'));
+  var type = (path.split ('.')).pop ();
+  var actuals = doctest (path, options);
+  var expecteds = require (pathlib.resolve (path, '..', 'results.json'));
   for (var idx = 0; idx < expecteds.length; idx += 1) {
-    printResult(actuals[idx],
-                expecteds[idx][1],
-                expecteds[idx][0] + ' [' + type + ']');
+    printResult (actuals[idx],
+                 expecteds[idx][1],
+                 expecteds[idx][0] + ' [' + type + ']');
   }
 }
 
@@ -57,66 +57,66 @@ function testCommand(command, expected) {
   var stdout;
   var stderr = '';
   try {
-    stdout = execSync(command, {encoding: 'utf8', stdio: 'pipe'});
+    stdout = execSync (command, {encoding: 'utf8', stdio: 'pipe'});
   } catch (err) {
     status = err.status;
     stdout = err.stdout;
     stderr = err.stderr;
   }
-  printResult(status, expected.status, command + ' [status]');
-  printResult(stdout, expected.stdout, command + ' [stdout]');
-  printResult(stderr, expected.stderr, command + ' [stderr]');
+  printResult (status, expected.status, command + ' [status]');
+  printResult (stdout, expected.stdout, command + ' [stdout]');
+  printResult (stderr, expected.stderr, command + ' [stderr]');
 }
 
 
-testModule('test/shared/index.js', {silent: true});
-testModule('test/shared/index.coffee', {silent: true});
-testModule('test/line-endings/CR.js', {silent: true});
-testModule('test/line-endings/CR.coffee', {silent: true});
-testModule('test/line-endings/CR+LF.js', {silent: true});
-testModule('test/line-endings/CR+LF.coffee', {silent: true});
-testModule('test/line-endings/LF.js', {silent: true});
-testModule('test/line-endings/LF.coffee', {silent: true});
-testModule('test/exceptions/index.js', {silent: true});
-testModule('test/statements/index.js', {silent: true});
-testModule('test/fantasy-land/index.js', {silent: true});
-testModule('test/transcribe/index.js', {prefix: '.', silent: true});
-testModule('test/transcribe/index.coffee', {prefix: '.', silent: true});
-testModule('test/amd/index.js', {module: 'amd', silent: true});
-testModule('test/commonjs/require/index.js', {module: 'commonjs', silent: true});
-testModule('test/commonjs/exports/index.js', {module: 'commonjs', silent: true});
-testModule('test/commonjs/module.exports/index.js', {module: 'commonjs', silent: true});
-testModule('test/commonjs/strict/index.js', {module: 'commonjs', silent: true});
-testModule('test/bin/executable', {type: 'js', silent: true});
-testModule('test/harmony/index.js', {silent: true});
+testModule ('test/shared/index.js', {silent: true});
+testModule ('test/shared/index.coffee', {silent: true});
+testModule ('test/line-endings/CR.js', {silent: true});
+testModule ('test/line-endings/CR.coffee', {silent: true});
+testModule ('test/line-endings/CR+LF.js', {silent: true});
+testModule ('test/line-endings/CR+LF.coffee', {silent: true});
+testModule ('test/line-endings/LF.js', {silent: true});
+testModule ('test/line-endings/LF.coffee', {silent: true});
+testModule ('test/exceptions/index.js', {silent: true});
+testModule ('test/statements/index.js', {silent: true});
+testModule ('test/fantasy-land/index.js', {silent: true});
+testModule ('test/transcribe/index.js', {prefix: '.', silent: true});
+testModule ('test/transcribe/index.coffee', {prefix: '.', silent: true});
+testModule ('test/amd/index.js', {module: 'amd', silent: true});
+testModule ('test/commonjs/require/index.js', {module: 'commonjs', silent: true});
+testModule ('test/commonjs/exports/index.js', {module: 'commonjs', silent: true});
+testModule ('test/commonjs/module.exports/index.js', {module: 'commonjs', silent: true});
+testModule ('test/commonjs/strict/index.js', {module: 'commonjs', silent: true});
+testModule ('test/bin/executable', {type: 'js', silent: true});
+testModule ('test/harmony/index.js', {silent: true});
 
-testCommand('bin/doctest --xxx', {
+testCommand ('bin/doctest --xxx', {
   status: 1,
   stdout: '',
-  stderr: unlines([
+  stderr: unlines ([
     "error: unknown option `--xxx'"
   ])
 });
 
-testCommand('bin/doctest --type', {
+testCommand ('bin/doctest --type', {
   status: 1,
   stdout: '',
-  stderr: unlines([
+  stderr: unlines ([
     "error: option `-t, --type <type>' argument missing"
   ])
 });
 
-testCommand('bin/doctest --type xxx', {
+testCommand ('bin/doctest --type xxx', {
   status: 1,
   stdout: '',
-  stderr: unlines([
+  stderr: unlines ([
     "error: Invalid type `xxx'"
   ])
 });
 
-testCommand('bin/doctest test/shared/index.js', {
+testCommand ('bin/doctest test/shared/index.js', {
   status: 1,
-  stdout: unlines([
+  stdout: unlines ([
     'running doctests in test/shared/index.js...',
     '......x.x...........x........x',
     'FAIL: expected 5 on line 31 (got 4)',
@@ -128,9 +128,9 @@ testCommand('bin/doctest test/shared/index.js', {
   stderr: ''
 });
 
-testCommand('bin/doctest test/shared/index.coffee', {
+testCommand ('bin/doctest test/shared/index.coffee', {
   status: 1,
-  stdout: unlines([
+  stdout: unlines ([
     'running doctests in test/shared/index.coffee...',
     '......x.x...........x........x',
     'FAIL: expected 5 on line 31 (got 4)',
@@ -142,9 +142,9 @@ testCommand('bin/doctest test/shared/index.coffee', {
   stderr: ''
 });
 
-testCommand('bin/doctest test/shared/index.js test/shared/index.coffee', {
+testCommand ('bin/doctest test/shared/index.js test/shared/index.coffee', {
   status: 1,
-  stdout: unlines([
+  stdout: unlines ([
     'running doctests in test/shared/index.js...',
     '......x.x...........x........x',
     'FAIL: expected 5 on line 31 (got 4)',
@@ -163,41 +163,41 @@ testCommand('bin/doctest test/shared/index.js test/shared/index.coffee', {
   stderr: ''
 });
 
-testCommand('bin/doctest --silent test/shared/index.js', {
+testCommand ('bin/doctest --silent test/shared/index.js', {
   status: 1,
   stdout: '',
   stderr: ''
 });
 
-testCommand('bin/doctest test/bin/executable', {
+testCommand ('bin/doctest test/bin/executable', {
   status: 1,
   stdout: '',
-  stderr: unlines([
+  stderr: unlines ([
     'error: Cannot infer type from extension'
   ])
 });
 
-testCommand('bin/doctest --type js test/bin/executable', {
+testCommand ('bin/doctest --type js test/bin/executable', {
   status: 0,
-  stdout: unlines([
+  stdout: unlines ([
     'running doctests in test/bin/executable...',
     '.'
   ]),
   stderr: ''
 });
 
-testCommand('bin/doctest --module commonjs lib/doctest.js', {
+testCommand ('bin/doctest --module commonjs lib/doctest.js', {
   status: 0,
-  stdout: unlines([
+  stdout: unlines ([
     'running doctests in lib/doctest.js...',
     '...'
   ]),
   stderr: ''
 });
 
-testCommand('bin/doctest --print test/commonjs/exports/index.js', {
+testCommand ('bin/doctest --print test/commonjs/exports/index.js', {
   status: 0,
-  stdout: unlines([
+  stdout: unlines ([
     '__doctest.enqueue({',
     '  type: "input",',
     '  thunk: function() {',
@@ -219,9 +219,9 @@ testCommand('bin/doctest --print test/commonjs/exports/index.js', {
   stderr: ''
 });
 
-testCommand('bin/doctest --print --module amd test/amd/index.js', {
+testCommand ('bin/doctest --print --module amd test/amd/index.js', {
   status: 0,
-  stdout: unlines([
+  stdout: unlines ([
     'define(function() {',
     '  // Convert degrees Celsius to degrees Fahrenheit.',
     '  //',
@@ -257,9 +257,9 @@ testCommand('bin/doctest --print --module amd test/amd/index.js', {
   stderr: ''
 });
 
-testCommand('bin/doctest --print --module commonjs test/commonjs/exports/index.js', {
+testCommand ('bin/doctest --print --module commonjs test/commonjs/exports/index.js', {
   status: 0,
-  stdout: unlines([
+  stdout: unlines ([
     'void function() {',
     '  var __doctest = {',
     '    require: require,',
@@ -294,9 +294,9 @@ testCommand('bin/doctest --print --module commonjs test/commonjs/exports/index.j
 });
 
 
-process.stdout.write(
+process.stdout.write (
   failures === 0 ? '\n  ' + green + '0 test failures' + reset + '\n\n' :
   failures === 1 ? '\n  ' + red + '1 test failure' + reset + '\n\n' :
   /* otherwise */  '\n  ' + red + failures + ' test failures' + reset + '\n\n'
 );
-process.exit(failures === 0 ? 0 : 1);
+process.exit (failures === 0 ? 0 : 1);


### PR DESCRIPTION
<https://github.com/sanctuary-js/sanctuary-scripts/releases/tag/v2.0.0>

@danse, read sanctuary-js/sanctuary#438 if you're interested in the reasons for writing `f (x)` rather than `f(x)`.
