### PR TITLE
use ‘INPUT’ and ‘OUTPUT’ constants

### DIFF
--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -82,6 +82,14 @@ function matchLine(prefix, s) {
     null;
 }
 
+//  object :: Array (Array2 String Any) -> Object
+function object(pairs) {
+  return pairs.reduce (function(object, pair) {
+    object[pair[0]] = pair[1];
+    return object;
+  }, {});
+}
+
 //  quote :: String -> String
 function quote(s) {
   return "'" + s.replace (/'/g, "\\'") + "'";
@@ -136,9 +144,13 @@ function toModule(source, moduleType) {
   }
 }
 
+var INPUT = 'input';
+var OUTPUT = 'output';
+var DEFAULT = 'default';
+
 //  normalizeTest :: { output :: { value :: String } } -> Undefined
 function normalizeTest($test) {
-  var $output = $test.output;
+  var $output = $test[OUTPUT];
   if ($output != null) {
     var match = $output.value.match (/^![ ]?([^:]*)(?::[ ]?(.*))?$/);
     $test['!'] = match != null;
@@ -147,10 +159,6 @@ function normalizeTest($test) {
     }
   }
 }
-
-var INPUT = 'input';
-var OUTPUT = 'output';
-var DEFAULT = 'default';
 
 //  Location = { start :: { line :: Integer, column :: Integer }
 //             ,   end :: { line :: Integer, column :: Integer } }
@@ -203,10 +211,10 @@ function transformComments(prefix, comments) {
         var $2 = match[2];
         if ($1 === '>') {
           accum.state = INPUT;
-          accum.tests.push ({
-            commentIndex: commentIndex,
-            input: {value: $2, loc: {start: start, end: end}}
-          });
+          accum.tests.push (object ([
+            ['commentIndex', commentIndex],
+            [INPUT, {value: $2, loc: {start: start, end: end}}]
+          ]));
         } else if ($1 !== '' || accum.state === INPUT) {
           var last = accum.tests[accum.tests.length - 1];
           last.commentIndex = commentIndex;
@@ -260,23 +268,23 @@ function substring(input, start, end) {
 }
 
 function wrap$js(test) {
-  var type = (esprima.parse (test.input.value)).body[0].type;
+  var type = (esprima.parse (test[INPUT].value)).body[0].type;
   return type === 'FunctionDeclaration' || type === 'VariableDeclaration' ?
-    test.input.value :
+    test[INPUT].value :
     [
       '__doctest.enqueue({',
-      '  type: "input",',
+      '  type: "' + INPUT + '",',
       '  thunk: function() {',
-      '    return ' + test.input.value + ';',
+      '    return ' + test[INPUT].value + ';',
       '  }',
       '});'
-    ].concat (test.output == null ? [] : [
+    ].concat (test[OUTPUT] == null ? [] : [
       '__doctest.enqueue({',
-      '  type: "output",',
-      '  ":": ' + test.output.loc.start.line + ',',
+      '  type: "' + OUTPUT + '",',
+      '  ":": ' + test[OUTPUT].loc.start.line + ',',
       '  "!": ' + test['!'] + ',',
       '  thunk: function() {',
-      '    return ' + test.output.value + ';',
+      '    return ' + test[OUTPUT].value + ';',
       '  }',
       '});'
     ]).join ('\n');
@@ -285,17 +293,17 @@ function wrap$js(test) {
 function wrap$coffee(test) {
   return [
     '__doctest.enqueue {',
-    '  type: "input"',
+    '  type: "' + INPUT + '"',
     '  thunk: ->',
-    indentN (4, test.input.value),
+    indentN (4, test[INPUT].value),
     '}'
-  ].concat (test.output == null ? [] : [
+  ].concat (test[OUTPUT] == null ? [] : [
     '__doctest.enqueue {',
-    '  type: "output"',
-    '  ":": ' + test.output.loc.start.line,
+    '  type: "' + OUTPUT + '"',
+    '  ":": ' + test[OUTPUT].loc.start.line,
     '  "!": ' + test['!'],
     '  thunk: ->',
-    indentN (4, test.output.value),
+    indentN (4, test[OUTPUT].value),
     '}'
   ]).join ('\n');
 }
@@ -342,10 +350,10 @@ function rewrite$js(prefix, input) {
   var lineTests = transformComments (prefix, comments.Line);
 
   var chunks = lineTests
-    .concat ([{input: bookend}])
+    .concat ([object ([[INPUT, bookend]])])
     .reduce (function(accum, test) {
-      accum.chunks.push (substring (input, accum.loc, test.input.loc.start));
-      accum.loc = (test.output == null ? test.input : test.output).loc.end;
+      accum.chunks.push (substring (input, accum.loc, test[INPUT].loc.start));
+      accum.loc = (test[OUTPUT] == null ? test[INPUT] : test[OUTPUT]).loc.end;
       return accum;
     }, {chunks: [], loc: {line: 1, column: 0}})
     .chunks;
@@ -402,7 +410,10 @@ function rewrite$coffee(prefix, input) {
         var $2 = match[2];
         if ($1 === '>') {
           accum.state = INPUT;
-          accum.tests.push ({indent: indent, input: {value: $2}});
+          accum.tests.push (object ([
+            ['indent', indent],
+            [INPUT, {value: $2}]
+          ]));
         } else if ($1 !== '' || accum.state === INPUT) {
           var last = accum.tests[accum.tests.length - 1];
           if ($1 !== '') {


### PR DESCRIPTION
We should use these identifiers consistently rather than hard-code their values in some places.
