### PR TITLE
rearrange functions in dependency order

### DIFF
--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -27,116 +27,53 @@ const inferType = path => {
   }
 };
 
-const evaluate = (moduleType, source, path) =>
-  moduleType === 'commonjs' ?
-    commonjsEval (source, path) :
-    functionEval (source);
-
-module.exports = ({
-  module,
-  prefix = '',
-  openingDelimiter,
-  closingDelimiter,
-  print,
-  silent,
-  type,
-}) => path => {
-  if (module != null &&
-      module !== 'amd' &&
-      module !== 'commonjs') {
-    return Promise.reject (new Error (`Invalid module \`${module}'`));
-  }
-  if (type != null &&
-      type !== 'coffee' &&
-      type !== 'js') {
-    return Promise.reject (new Error (`Invalid type \`${type}'`));
-  }
-
-  const type_ = type == null ? inferType (path) : type;
-  if (type_ == null) {
-    return Promise.reject (new Error (
-      'Cannot infer type from extension'
-    ));
-  }
-
-  const rewriters = {coffee: rewrite$coffee, js: rewrite$js};
-  const source = toModule (
-    rewriters[type_] ({prefix,
-                       openingDelimiter,
-                       closingDelimiter,
-                       sourceType: 'script'})
-                     (fs.readFileSync (path, 'utf8')
-                      .replace (/\r\n?/g, '\n')
-                      .replace (/^#!.*/, '')),
-    module
-  );
-
-  if (print) {
-    console.log (source.replace (/\n$/, ''));
-    return Promise.resolve ([]);
-  } else if (silent) {
-    return Promise.resolve (evaluate (module, source, path));
-  } else {
-    console.log (`running doctests in ${path}...`);
-    const results = evaluate (module, source, path);
-    log (results);
-    return Promise.resolve (results);
-  }
-};
-
 //    indentN :: Integer -> String -> String
 const indentN = n => s => s.replace (/^(?!$)/gm, ' '.repeat (n));
 
 //    quote :: String -> String
 const quote = s => `'${s.replace (/'/g, "\\'")}'`;
 
-//    show :: a -> String
-const show = x =>
-  Object.prototype.toString.call (x) === '[object Error]' ?
-    String (x) :
-    _show (x);
+const wrap$js = sourceType => test => {
+  const ast = esprima.parse (test.input.value, {sourceType});
+  const {type} = ast.body[0];
+  return type === 'FunctionDeclaration' ||
+         type === 'ImportDeclaration' ||
+         type === 'VariableDeclaration' ?
+    test.input.value :
+    `
+__doctest.enqueue({
+  type: "input",
+  thunk: () => {
+    return ${test.input.value};
+  },
+});
+${test.output == null ? '' : `
+__doctest.enqueue({
+  type: "output",
+  ":": ${test.output.loc.start.line},
+  "!": ${test['!']},
+  thunk: () => {
+    return ${test.output.value};
+  },
+});
+`}`;
+};
 
-//    arrowWrap :: String -> String
-const arrowWrap = s => `void (() => {\n${indentN (2) (s)}})();`;
-
-//    toModule :: (String, String?) -> String
-const toModule = (source, moduleType) => {
-  switch (moduleType) {
-    case 'amd':
-      return `
-${source}
-function define(...args) {
-  args[args.length - 1]();
+const wrap$coffee = test => `
+__doctest.enqueue {
+  type: "input"
+  thunk: ->
+${indentN (4) (test.input.value)}
 }
-`;
-    case 'commonjs':
-      return arrowWrap (`
-const __doctest = {
-  require,
-  queue: [],
-  enqueue: function(io) { this.queue.push(io); },
-};
-
-${arrowWrap (source)}
-
-(module.exports || exports).__doctest = __doctest;
-`);
-    default:
-      return source;
-  }
-};
-
-//    normalizeTest :: { output :: { value :: String } } -> Undefined
-const normalizeTest = $test => {
-  const $output = $test.output;
-  if ($output != null) {
-    const match = $output.value.match (/^![ ]?([^:]*)(?::[ ]?(.*))?$/);
-    $test['!'] = match != null;
-    if ($test['!']) {
-      $output.value = `new ${match[1]}(${quote (match[2] || '')})`;
-    }
-  }
-};
+${test.output == null ? '' : `
+__doctest.enqueue {
+  type: "output"
+  ":": ${test.output.loc.start.line}
+  "!": ${test['!']}
+  thunk: ->
+${indentN (4) (test.output.value)}
+}
+`}`;
 
 const processLine = (
   options,        // :: { prefix :: String
@@ -172,6 +109,18 @@ const processLine = (
       const $test = accum.tests[accum.tests.length - 1];
       $test[accum.state = 'output'] = {value};
       output ($test);
+    }
+  }
+};
+
+//    normalizeTest :: { output :: { value :: String } } -> Undefined
+const normalizeTest = $test => {
+  const $output = $test.output;
+  if ($output != null) {
+    const match = $output.value.match (/^![ ]?([^:]*)(?::[ ]?(.*))?$/);
+    $test['!'] = match != null;
+    if ($test['!']) {
+      $output.value = `new ${match[1]}(${quote (match[2] || '')})`;
     }
   }
 };
@@ -281,48 +230,6 @@ const substring = (input, start, end) => {
   );
 };
 
-const wrap$js = sourceType => test => {
-  const ast = esprima.parse (test.input.value, {sourceType});
-  const {type} = ast.body[0];
-  return type === 'FunctionDeclaration' ||
-         type === 'ImportDeclaration' ||
-         type === 'VariableDeclaration' ?
-    test.input.value :
-    `
-__doctest.enqueue({
-  type: "input",
-  thunk: () => {
-    return ${test.input.value};
-  },
-});
-${test.output == null ? '' : `
-__doctest.enqueue({
-  type: "output",
-  ":": ${test.output.loc.start.line},
-  "!": ${test['!']},
-  thunk: () => {
-    return ${test.output.value};
-  },
-});
-`}`;
-};
-
-const wrap$coffee = test => `
-__doctest.enqueue {
-  type: "input"
-  thunk: ->
-${indentN (4) (test.input.value)}
-}
-${test.output == null ? '' : `
-__doctest.enqueue {
-  type: "output"
-  ":": ${test.output.loc.start.line}
-  "!": ${test['!']}
-  thunk: ->
-${indentN (4) (test.output.value)}
-}
-`}`;
-
 const rewrite$js = ({
   sourceType,
   prefix,
@@ -414,8 +321,6 @@ const rewrite$js = ({
     .join ('');
 };
 
-module.exports.rewrite$js = rewrite$js;
-
 const rewrite$coffee = ({
   prefix,
   openingDelimiter,
@@ -477,31 +382,41 @@ const rewrite$coffee = ({
   );
 };
 
-const functionEval = source => {
-  //  Functions created via the Function function are always run in the
-  //  global context, which ensures that doctests can't access variables
-  //  in _this_ context.
-  //
-  //  The `evaluate` function takes one argument, named `__doctest`.
-  const evaluate = Function ('__doctest', source);
-  const queue = [];
-  evaluate ({enqueue: io => { queue.push (io); }});
-  return run (queue);
+//    arrowWrap :: String -> String
+const arrowWrap = s => `void (() => {\n${indentN (2) (s)}})();`;
+
+//    toModule :: (String, String?) -> String
+const toModule = (source, moduleType) => {
+  switch (moduleType) {
+    case 'amd':
+      return `
+${source}
+function define(...args) {
+  args[args.length - 1]();
+}
+`;
+    case 'commonjs':
+      return arrowWrap (`
+const __doctest = {
+  require,
+  queue: [],
+  enqueue: function(io) { this.queue.push(io); },
 };
 
-const commonjsEval = (source, path) => {
-  const abspath = resolve (path)
-                  .replace (/[.][^.]+$/, `-${Date.now ()}.js`);
+${arrowWrap (source)}
 
-  fs.writeFileSync (abspath, source);
-  let queue;
-  try {
-    ({queue} = (require (abspath)).__doctest);
-  } finally {
-    fs.unlinkSync (abspath);
+(module.exports || exports).__doctest = __doctest;
+`);
+    default:
+      return source;
   }
-  return run (queue);
 };
+
+//    show :: a -> String
+const show = x =>
+  Object.prototype.toString.call (x) === '[object Error]' ?
+    String (x) :
+    _show (x);
 
 const run = queue =>
   queue.reduce ((accum, io) => {
@@ -541,7 +456,36 @@ const run = queue =>
     return accum;
   }, {results: [], thunk: null}).results;
 
-module.exports.run = run;
+const commonjsEval = (source, path) => {
+  const abspath = resolve (path)
+                  .replace (/[.][^.]+$/, `-${Date.now ()}.js`);
+
+  fs.writeFileSync (abspath, source);
+  let queue;
+  try {
+    ({queue} = (require (abspath)).__doctest);
+  } finally {
+    fs.unlinkSync (abspath);
+  }
+  return run (queue);
+};
+
+const functionEval = source => {
+  //  Functions created via the Function function are always run in the
+  //  global context, which ensures that doctests can't access variables
+  //  in _this_ context.
+  //
+  //  The `evaluate` function takes one argument, named `__doctest`.
+  const evaluate = Function ('__doctest', source);
+  const queue = [];
+  evaluate ({enqueue: io => { queue.push (io); }});
+  return run (queue);
+};
+
+const evaluate = (moduleType, source, path) =>
+  moduleType === 'commonjs' ?
+    commonjsEval (source, path) :
+    functionEval (source);
 
 const log = results => {
   console.log (
@@ -555,5 +499,61 @@ const log = results => {
     }
   });
 };
+
+module.exports = ({
+  module,
+  prefix = '',
+  openingDelimiter,
+  closingDelimiter,
+  print,
+  silent,
+  type,
+}) => path => {
+  if (module != null &&
+      module !== 'amd' &&
+      module !== 'commonjs') {
+    return Promise.reject (new Error (`Invalid module \`${module}'`));
+  }
+  if (type != null &&
+      type !== 'coffee' &&
+      type !== 'js') {
+    return Promise.reject (new Error (`Invalid type \`${type}'`));
+  }
+
+  const type_ = type == null ? inferType (path) : type;
+  if (type_ == null) {
+    return Promise.reject (new Error (
+      'Cannot infer type from extension'
+    ));
+  }
+
+  const rewriters = {coffee: rewrite$coffee, js: rewrite$js};
+  const source = toModule (
+    rewriters[type_] ({prefix,
+                       openingDelimiter,
+                       closingDelimiter,
+                       sourceType: 'script'})
+                     (fs.readFileSync (path, 'utf8')
+                      .replace (/\r\n?/g, '\n')
+                      .replace (/^#!.*/, '')),
+    module
+  );
+
+  if (print) {
+    console.log (source.replace (/\n$/, ''));
+    return Promise.resolve ([]);
+  } else if (silent) {
+    return Promise.resolve (evaluate (module, source, path));
+  } else {
+    console.log (`running doctests in ${path}...`);
+    const results = evaluate (module, source, path);
+    log (results);
+    return Promise.resolve (results);
+  }
+};
+
+module.exports.rewrite$js = rewrite$js;
+
+module.exports.run = run;
 
 module.exports.log = log;

--- a/lib/doctest.mjs
+++ b/lib/doctest.mjs
@@ -5,6 +5,30 @@ import {promisify} from 'util';
 import doctest from './doctest.js';
 
 
+const wrap = source => `
+export const __doctest = {
+  queue: [],
+  enqueue: function(io) { this.queue.push(io); },
+};
+
+${source}
+`;
+
+const evaluate = (source, path) => {
+  const abspath = resolve (path)
+                  .replace (/[.][^.]+$/, `-${Date.now ()}.mjs`);
+
+  const cleanup = f => x =>
+    promisify (fs.unlink) (abspath)
+    .then (() => f (x));
+
+  return promisify (fs.writeFile) (abspath, source)
+    .then (() => import (abspath))
+    .then (module => doctest.run (module.__doctest.queue))
+    .then (cleanup (Promise.resolve.bind (Promise)),
+           cleanup (Promise.reject.bind (Promise)));
+};
+
 export default options => async path => {
   if (options.module !== 'esm') return doctest (options) (path);
 
@@ -41,28 +65,4 @@ export default options => async path => {
     return evaluate (source, path)
       .then (results => ((doctest.log (results), results)));
   }
-};
-
-const wrap = source => `
-export const __doctest = {
-  queue: [],
-  enqueue: function(io) { this.queue.push(io); },
-};
-
-${source}
-`;
-
-const evaluate = (source, path) => {
-  const abspath = resolve (path)
-                  .replace (/[.][^.]+$/, `-${Date.now ()}.mjs`);
-
-  const cleanup = f => x =>
-    promisify (fs.unlink) (abspath)
-    .then (() => f (x));
-
-  return promisify (fs.writeFile) (abspath, source)
-    .then (() => import (abspath))
-    .then (module => doctest.run (module.__doctest.queue))
-    .then (cleanup (Promise.resolve.bind (Promise)),
-           cleanup (Promise.reject.bind (Promise)));
 };


### PR DESCRIPTION
The new order of __doctest.js__ is much more sensible:

```
inferType

indentN

quote

wrap$js

wrap$coffee
 -> indentN

processLine

normalizeTest
 -> quote

transformComments
 -> processLine
 -> normalizeTest

substring

rewrite$js
 -> wrap$js
 -> transformComments
 -> substring

rewrite$coffee
 -> indentN
 -> wrap$coffee
 -> processLine
 -> normalizeTest

arrowWrap
 -> indentN

toModule
 -> arrowWrap

show

run
 -> show

commonjsEval
 -> run

functionEval
 -> run

evaluate
 -> commonjsEval
 -> functionEval

log

module.exports
 -> inferType
 -> rewrite$js
 -> rewrite$coffee
 -> toModule
 -> evaluate
 -> log
```
