### PR TITLE
support ES2020 syntax

### DIFF
--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -37,7 +37,7 @@ const wrap$js = sourceType => test => {
   const source = test.input.value;
   const ast = acorn.parse (
     source.startsWith ('{') && source.endsWith ('}') ? `(${source})` : source,
-    {ecmaVersion: 2018, sourceType}
+    {ecmaVersion: 'latest', sourceType}
   );
   const {type} = ast.body[0];
   return type === 'FunctionDeclaration' ||
@@ -270,7 +270,7 @@ const rewrite$js = ({
   const getComments = input => {
     const comments = [];
     acorn.parse (input, {
-      ecmaVersion: 2018,
+      ecmaVersion: 'latest',
       sourceType,
       locations: true,
       onComment: comments,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "acorn": "7.3.x",
+    "acorn": "8.0.x",
     "coffeescript": "1.12.x",
     "commander": "2.20.x",
     "sanctuary-show": "1.0.x",

--- a/test/es2020/index.js
+++ b/test/es2020/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// > ({})?.x
+// undefined
+// > ({}) ?? x
+// {}

--- a/test/es2020/results.json
+++ b/test/es2020/results.json
@@ -1,0 +1,20 @@
+[
+  [
+    "optional chaining",
+    [
+      true,
+      "undefined",
+      "undefined",
+      4
+    ]
+  ],
+  [
+    "nullish coalescing",
+    [
+      true,
+      "{}",
+      "{}",
+      6
+    ]
+  ]
+]

--- a/test/index.js
+++ b/test/index.js
@@ -83,6 +83,7 @@ const moduleTests = Promise.all ([
   testModule ('test/bin/executable', {type: 'js', silent: true}),
   testModule ('test/es2015/index.js', {silent: true}),
   testModule ('test/es2018/index.js', {silent: true}),
+  testModule ('test/es2020/index.js', {silent: true}),
 ]);
 
 testCommand ('bin/doctest', {


### PR DESCRIPTION
New ES2020 operators such as optional chaining or nullish coalescing are not supported:
```javascript
({})?.x
({}) ?? x
```
I also had to update Acorn >= 8.x because 7.3.x was looping indefinitely with ecmaScript: "latest" (fixed in https://github.com/acornjs/acorn/issues/981 ).

Alternatives would be to only force es: 2020 in place of "latest" and ideally adding an additional command line flag, but JavaScript being hopefully backward compatible :) , I think "latest" would be more practical on the long term for most users.