### PR TITLE
update Node.js version range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os: linux
 dist: focal
 language: node_js
 node_js:
-  - "10"
+  - "10.2.0"
   - "12"
   - "13"
   - "14"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "git://github.com/davidchambers/doctest.git"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=10.2.0"
   },
   "dependencies": {
     "acorn": "7.3.x",


### PR DESCRIPTION
[2018-05-23, Version 10.2.0 (Current), @MylesBorins][1]:

>   - __esm__:
>       - Builtin modules (e.g. `fs`) now provide named exports in ES6 modules. (Gus Caplan) [#20403][2]


[1]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.2.0
[2]: https://github.com/nodejs/node/pull/20403
