### PR TITLE
test: integrate oletus and c8

### DIFF
--- a/.config
+++ b/.config
@@ -1,6 +1,6 @@
 repo-owner = davidchambers
 repo-name = doctest
 author-name = David Chambers <dc@davidchambers.me>
-source-files = bin/doctest lib/*.js lib/*.mjs
+source-files = bin/doctest lib/*.js
 readme-source-files =
 version-tag-prefix =

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/coverage/
 /node_modules/

--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -493,6 +493,7 @@ const commonjsEval = path => async source => {
     fs.unlinkSync (abspath);
   }
   return run (queue);
+  /* c8 ignore next */
 };
 
 const functionEval = async source => {
@@ -505,6 +506,7 @@ const functionEval = async source => {
   const queue = [];
   evaluate ({enqueue: io => { queue.push (io); }});
   return run (queue);
+  /* c8 ignore next */
 };
 
 const log = results => {
@@ -576,4 +578,5 @@ export default options => async path => {
                  commonjsEval (path) :
                  functionEval);
   }
+  /* c8 ignore next */
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
   },
   "devDependencies": {
     "babel-eslint": "10.1.x",
+    "c8": "7.10.x",
+    "oletus": "3.2.x",
     "sanctuary-scripts": "5.0.x"
   },
   "scripts": {

--- a/scripts/test
+++ b/scripts/test
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-node -- test/index.js
+source "${BASH_SOURCE%/*}/../node_modules/sanctuary-scripts/functions"
+
+set +f ; shopt -s nullglob
+files=($(get source-files))
+set -f ; shopt -u nullglob
+
+node_modules/.bin/c8 \
+  --check-coverage \
+  --100 \
+  --reporter text \
+  --reporter html \
+  $(printf ' --include %s' "${files[@]}") \
+  node -- node_modules/.bin/oletus -- test/index.js


### PR DESCRIPTION
Thanks to #146 we can now use [oletus][1] and [c8][2] for testing and coverage. Until these are included in [sanctuary-scripts][3] we will depend on them directly.

The source code is unchanged but for the addition of three `/* c8 ignore next */` directives. These are workarounds for bugs in V8's coverage reporting. These bugs have already been fixed; the directives are unnecessary when using v16.0.0.


[1]: https://www.npmjs.com/package/oletus
[2]: https://www.npmjs.com/package/c8
[3]: https://www.npmjs.com/package/sanctuary-scripts
