### PR TITLE
assume JavaScript

### DIFF
--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -544,14 +544,10 @@ export default options => async path => {
                          (rewriteJs ('module')))
                 (evaluateModule (path));
   } else {
-    const ext = extname (path);
-    if (options.type == null && !(['.coffee', '.js'].includes (ext))) {
-      throw new Error ('Cannot infer type from extension');
-    }
     return test (options)
                 (path)
                 ((options.type === 'coffee' ||
-                  options.type == null && ext === '.coffee') ?
+                  options.type == null && extname (path) === '.coffee') ?
                  rewriteCoffee :
                  compose (compose (toModule (options.module)))
                          (rewriteJs ('script')))

--- a/test/index.js
+++ b/test/index.js
@@ -170,10 +170,11 @@ testCommand ('bin/doctest --silent test/shared/index.js', {
 });
 
 testCommand ('bin/doctest test/bin/executable', {
-  status: 1,
-  stdout: '',
-  stderr: `error: Cannot infer type from extension
+  status: 0,
+  stdout: `running doctests in test/bin/executable...
+.
 `,
+  stderr: '',
 });
 
 testCommand ('bin/doctest --type js test/bin/executable', {


### PR DESCRIPTION
Currently we require `--type js` or `--type coffee` for files without extensions. It seems reasonable to assume that any file without the __.coffee__ extension is a JavaScript file (one can still specify `--type coffee` if necessary).
