### PR TITLE
command: use exit code 0 if no files are specified

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -2,14 +2,6 @@ import doctest from './doctest.js';
 import program from './program.js';
 
 
-//    formatErrors :: Array String -> String
-const formatErrors = errors => (errors.map (s => `error: ${s}\n`)).join ('');
-
-if (program.args.length === 0) {
-  process.stderr.write (formatErrors (['No files for doctesting provided']));
-  process.exit (1);
-}
-
 Promise.all (
   program.args.map (path =>
     doctest (program) (path)
@@ -23,7 +15,7 @@ Promise.all (
     process.exit (statuses.every (s => s === 0) ? 0 : 1);
   },
   err => {
-    process.stderr.write (formatErrors ([err.message]));
+    process.stderr.write (`${err}\n`);
     process.exit (1);
   }
 );

--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -529,10 +529,10 @@ const test = options => path => rewrite => evaluate => {
 
 export default options => async path => {
   if (!([undefined, 'amd', 'commonjs', 'esm'].includes (options.module))) {
-    throw new Error (`Invalid module \`${options.module}'`);
+    throw new Error (`Invalid module ${show (options.module)}`);
   }
   if (!([undefined, 'coffee', 'js'].includes (options.type))) {
-    throw new Error (`Invalid type \`${options.type}'`);
+    throw new Error (`Invalid type ${show (options.type)}`);
   }
   if (options.module === 'esm') {
     if (options.type != null) {

--- a/test/index.js
+++ b/test/index.js
@@ -94,10 +94,9 @@ if (Number ((process.versions.node.split ('.'))[0]) >= 14) {
 }
 
 testCommand ('bin/doctest', {
-  status: 1,
+  status: 0,
   stdout: '',
-  stderr: `error: No files for doctesting provided
-`,
+  stderr: '',
 });
 
 testCommand ('bin/doctest --xxx', {
@@ -117,7 +116,7 @@ testCommand ('bin/doctest file.js --type', {
 testCommand ('bin/doctest file.js --type xxx', {
   status: 1,
   stdout: '',
-  stderr: `error: Invalid type \`xxx'
+  stderr: `Error: Invalid type "xxx"
 `,
 });
 
@@ -188,14 +187,14 @@ testCommand ('bin/doctest --type js test/bin/executable', {
 testCommand ('bin/doctest --module xxx file.js', {
   status: 1,
   stdout: '',
-  stderr: `error: Invalid module \`xxx'
+  stderr: `Error: Invalid module "xxx"
 `,
 });
 
 testCommand ('bin/doctest --module esm --type js file.js', {
   status: 1,
   stdout: '',
-  stderr: `error: Cannot use file type when module is "esm"
+  stderr: `Error: Cannot use file type when module is "esm"
 `,
 });
 


### PR DESCRIPTION
`doctest -- *.js` should succeed if no file path matches the glob.
