### PR TITLE
require output lines to be contiguous with input lines

### DIFF
--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -115,6 +115,11 @@ export const __doctest = {
 ${source}
 `;
 
+//    contiguous :: Line -> NonEmpty (Array Line) -> Boolean
+const contiguous = line => lines => (
+  line.number === lines[lines.length - 1].number + 1
+);
+
 //    Location = { start :: { line :: Integer, column :: Integer }
 //               ,   end :: { line :: Integer, column :: Integer } }
 
@@ -181,11 +186,18 @@ const transformComments = ({
             accum.tests[accum.tests.length - 1][accum.state].lines.push (line);
             accum.tests[accum.tests.length - 1][accum.state].loc.end = end;
           } else if (accum.state === 'input') {
-            accum.tests[accum.tests.length - 1].commentIndex = commentIndex;
-            accum.tests[accum.tests.length - 1][accum.state = 'output'] = {
-              lines: [line],
-              loc: {start, end},
-            };
+            //  A comment immediately following an input line is an output
+            //  line if and only if it contains non-whitespace characters.
+            const {lines} = accum.tests[accum.tests.length - 1].input;
+            if (contiguous (line) (lines) && unprefixed !== '') {
+              accum.tests[accum.tests.length - 1].commentIndex = commentIndex;
+              accum.tests[accum.tests.length - 1][accum.state = 'output'] = {
+                lines: [line],
+                loc: {start, end},
+              };
+            } else {
+              accum.state = 'open';
+            }
           }
         }
         return accum;
@@ -364,9 +376,16 @@ const rewriteCoffee = ({
             line
           );
         } else if (accum.state === 'input') {
-          accum.tests[accum.tests.length - 1][accum.state = 'output'] = {
-            lines: [line],
-          };
+          //  A comment immediately following an input line is an output
+          //  line if and only if it contains non-whitespace characters.
+          const {lines} = accum.tests[accum.tests.length - 1].input;
+          if (contiguous (line) (lines) && unprefixed !== '') {
+            accum.tests[accum.tests.length - 1][accum.state = 'output'] = {
+              lines: [line],
+            };
+          } else {
+            accum.state = 'open';
+          }
         }
       }
       return accum;

--- a/test/contiguity/index.coffee
+++ b/test/contiguity/index.coffee
@@ -1,0 +1,24 @@
+# inc :: Number -> Number
+#
+# > inc (0)
+inc = (x) -> x + 1
+
+# dec :: Number -> Number
+#
+# > dec (0)
+#
+# This is not an output line as it does not immediately follow an input line.
+dec = (x) -> x - 1
+
+# zero :: Integer -> Integer
+#
+# > zero (42)
+# 0
+zero = (x) ->
+  switch true
+    when x < 0
+      zero inc x
+    when x > 0
+      zero dec x
+    else
+      0

--- a/test/contiguity/index.js
+++ b/test/contiguity/index.js
@@ -1,0 +1,23 @@
+//  inc :: Number -> Number
+//
+//  > inc (0)
+const inc = x => x + 1;
+
+//  dec :: Number -> Number
+//
+//  > dec (0)
+//
+//  This is not an output line as it does not immediately follow an input line.
+const dec = x => x - 1;
+
+//  zero :: Integer -> Integer
+//
+//  > zero (42)
+//  0
+function zero(x) {
+  return x < 0 ? zero (inc (x)) :
+         x > 0 ? zero (dec (x)) :
+                 0;
+}
+
+zero (0);

--- a/test/contiguity/results.js
+++ b/test/contiguity/results.js
@@ -1,0 +1,8 @@
+export default ({Test, Line, Correct, Success}) => [
+
+  Test ('output line immediately following input line')
+       ([Line (15) ('> zero (42)')])
+       ([Line (16) ('0')])
+       (Correct (Success (0))),
+
+];

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ import resultsCommonJsExports from './commonjs/exports/results.js';
 import resultsCommonJsModuleExports from './commonjs/module.exports/results.js';
 import resultsCommonJsRequire from './commonjs/require/results.js';
 import resultsCommonJsStrict from './commonjs/strict/results.js';
+import resultsContiguity from './contiguity/results.js';
 import resultsEs2015 from './es2015/results.js';
 import resultsEs2018 from './es2018/results.js';
 import resultsEs2020 from './es2020/results.js';
@@ -211,6 +212,15 @@ testModule (resultsEs2018, 'test/es2018/index.js', {
 });
 
 testModule (resultsEs2020, 'test/es2020/index.js', {
+  silent: true,
+});
+
+testModule (resultsContiguity, 'test/contiguity/index.js', {
+  silent: true,
+});
+
+testModule (resultsContiguity, 'test/contiguity/index.coffee', {
+  coffee: true,
   silent: true,
 });
 


### PR DESCRIPTION
Closes #120

The result format now provides a line number for each input line and each output line, facilitating contiguity checks.

I took this opportunity to make other changes to the result format. :)

/cc @kocielnik
