### PR TITLE
require Node.js 14 or higher

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.22.0, 14, 16, 18]
+        node-version: [14.0.0, 16, 18]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -90,7 +90,7 @@ const normalizeTest = $test => {
     const match = $output.value.match (/^![ ]?([^:]*)(?::[ ]?(.*))?$/);
     $test['!'] = match != null;
     if ($test['!']) {
-      $output.value = `new ${match[1]}(${quote (match[2] || '')})`;
+      $output.value = `new ${match[1]}(${quote (match[2] ?? '')})`;
     }
   }
 };
@@ -272,7 +272,7 @@ const rewriteJs = sourceType => ({
         substring (input, accum.loc, test.input.loc.start)
         .replace (/[ \t]*$/, '')
       );
-      accum.loc = (test.output == null ? test.input : test.output).loc.end;
+      accum.loc = (test.output ?? test.input).loc.end;
       return accum;
     }, {chunks: [], loc: {line: 1, column: 0}})
     .chunks;
@@ -389,7 +389,7 @@ const __doctest = {
 
 ${arrowWrap (source)}
 
-(module.exports || exports).__doctest = __doctest;
+(module.exports ?? exports).__doctest = __doctest;
 `);
     default:
       return source;
@@ -498,7 +498,7 @@ const log = results => {
 
 const test = options => path => rewrite => evaluate => {
   const source = (
-    rewrite ({prefix: options.prefix || '',
+    rewrite ({prefix: options.prefix ?? '',
               openingDelimiter: options.openingDelimiter,
               closingDelimiter: options.closingDelimiter})
             (fs.readFileSync (path, 'utf8')

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git://github.com/davidchambers/doctest.git"
   },
   "engines": {
-    "node": ">=12.22.0"
+    "node": ">=14.0.0"
   },
   "dependencies": {
     "acorn": "8.5.x",

--- a/test/index.js
+++ b/test/index.js
@@ -85,9 +85,7 @@ testModule (resultsCommonJsDoctestRequire, 'test/commonjs/__doctest.require/inde
 testModule (resultsBin, 'test/bin/executable', {silent: true});
 testModule (resultsEs2015, 'test/es2015/index.js', {silent: true});
 testModule (resultsEs2018, 'test/es2018/index.js', {silent: true});
-if (Number ((process.versions.node.split ('.'))[0]) >= 14) {
-  testModule (resultsEs2020, 'test/es2020/index.js', {silent: true});
-}
+testModule (resultsEs2020, 'test/es2020/index.js', {silent: true});
 
 testCommand ('bin/doctest', {
   status: 0,
@@ -239,7 +237,7 @@ testCommand ('bin/doctest --print --module commonjs test/commonjs/exports/index.
     };
   })();
 
-  (module.exports || exports).__doctest = __doctest;
+  (module.exports ?? exports).__doctest = __doctest;
 })();
 `,
   stderr: '',


### PR DESCRIPTION
Node.js 12 is no longer maintained ([release schedule][1]).


[1]: https://github.com/nodejs/release#release-schedule
