### PR TITLE
test: improve ‘testModule’

### DIFF
--- a/test/shared/results.js
+++ b/test/shared/results.js
@@ -260,4 +260,13 @@ export default [
       149,
     ],
   ],
+  [
+    'the rewriter should not rely on automatic semicolon insertion',
+    [
+      false,
+      '"the rewriter should not rely"',
+      '"on automatic semicolon insertion"',
+      155,
+    ],
+  ],
 ];


### PR DESCRIPTION
Improvements:

  - `doctest` is now run once per module rather than once per test case;

  - the actual number of test cases must now match the expectation; and

  - descriptions printed by the test runner are now more informative.
