### PR TITLE
test: replace ‘null.length’ with ‘0..toString(1)’

### DIFF
--- a/test/exceptions/index.js
+++ b/test/exceptions/index.js
@@ -17,10 +17,10 @@
 // > sqrt(-1)
 // new Error('Invalid value')
 
-// > null.length
-// ! TypeError
+// > 0..toString(1)
+// ! RangeError
 
-// > null.length
+// > 0..toString(1)
 // ! Error
 
 // > sqrt(-1)

--- a/test/exceptions/results.js
+++ b/test/exceptions/results.js
@@ -57,8 +57,8 @@ export default [
     'evaluating input throws exception as expected, of expected type',
     [
       true,
-      '! TypeError',
-      '! TypeError',
+      '! RangeError',
+      '! RangeError',
       21,
     ],
   ],
@@ -66,7 +66,7 @@ export default [
     'evaluating input throws exception as expected, of unexpected type',
     [
       false,
-      '! TypeError',
+      '! RangeError',
       '! Error',
       24,
     ],

--- a/test/shared/index.coffee
+++ b/test/shared/index.coffee
@@ -30,9 +30,9 @@ do ->
   # > two + two
   # 5
 
-  8: 'TypeError captured and reported'
-  # > null.length
-  # ! TypeError
+  8: 'RangeError captured and reported'
+  # > 0.toString 1
+  # ! RangeError
   9: 'TypeError expected but not reported'
   # > [].length
   # ! TypeError

--- a/test/shared/index.js
+++ b/test/shared/index.js
@@ -30,9 +30,9 @@ global = 'global'
   // > two + two
   // 5
 
-  8, 'TypeError captured and reported'
-  // > null.length
-  // ! TypeError
+  8, 'RangeError captured and reported'
+  // > 0..toString(1)
+  // ! RangeError
   9, 'TypeError expected but not reported'
   // > [].length
   // ! TypeError

--- a/test/shared/results.coffee.js
+++ b/test/shared/results.coffee.js
@@ -63,11 +63,11 @@ export default [
     ],
   ],
   [
-    'TypeError captured and reported',
+    'RangeError captured and reported',
     [
       true,
-      '! TypeError',
-      '! TypeError',
+      '! RangeError',
+      '! RangeError',
       35,
     ],
   ],

--- a/test/shared/results.js
+++ b/test/shared/results.js
@@ -63,11 +63,11 @@ export default [
     ],
   ],
   [
-    'TypeError captured and reported',
+    'RangeError captured and reported',
     [
       true,
-      '! TypeError',
-      '! TypeError',
+      '! RangeError',
+      '! RangeError',
       35,
     ],
   ],


### PR DESCRIPTION
`null.length` is problematic because it behaves differently on different (supported) versions of Node.js:

```console
$ ASDF_NODEJS_VERSION=16.8.0 node --eval 'try { null.length } catch (err) { console.log (err.message) }'
Cannot read property 'length' of null

$ ASDF_NODEJS_VERSION=16.9.0 node --eval 'try { null.length } catch (err) { console.log (err.message) }'
Cannot read properties of null (reading 'length')
```

Currently doctest provides string representations of actual and expected values:

```javascript
'! Error: Invalid value'
```

String representations are to be replaced with rich values in #155:

```javascript
Failure (new Error ('Invalid value'))
```

I want to avoid conditional logic in the test suite:

```javascript
Failure (new TypeError (
  nodeVersion.major < 16 || nodeVersion.major === 16 && nodeVersion.minor < 9
  ? "Cannot read property 'length' of null"
  : "Cannot read properties of null (reading 'length')"
))
```

`0..toString(1)` behaves the same way on all supported versions of Node.js:

```javascript
Failure (new RangeError ('toString() radix argument must be between 2 and 36'))
```
