### PR TITLE
remove unused babel-eslint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "sanctuary-type-classes": "13.0.x"
   },
   "devDependencies": {
-    "babel-eslint": "10.1.x",
     "c8": "7.10.x",
     "oletus": "3.2.x",
     "sanctuary-scripts": "5.0.x"


### PR DESCRIPTION
This dependency was added in #113, and was necessary at that time.
