### PR TITLE
change `ecmaVersion` from `2020` to `2023`

### DIFF
--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -56,7 +56,7 @@ const wrapJs = sourceType => test => {
   const source = formatInput (0) (test.input.lines);
   const ast = acorn.parse (
     source.startsWith ('{') && source.endsWith ('}') ? `(${source})` : source,
-    {ecmaVersion: 2020, sourceType}
+    {ecmaVersion: 2023, sourceType}
   );
   const {type} = ast.body[0];
   if (type !== 'ExpressionStatement') return source;
@@ -260,7 +260,7 @@ const rewriteJs = sourceType => ({
   const getComments = input => {
     const comments = [];
     acorn.parse (input, {
-      ecmaVersion: 2020,
+      ecmaVersion: 2023,
       sourceType,
       locations: true,
       onComment: comments,


### PR DESCRIPTION
This permits doctests in modules that use 2021/2022/2023 language features.
