### PR TITLE
use `import.meta.resolve` to support relative and bare specifiers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.0.0, 18, 20]
+        node-version: [16.2.0, 18, 20]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/bin/doctest
+++ b/bin/doctest
@@ -11,7 +11,8 @@ const flags = idx >= 0 && idx < args.length - 1;
 require ('child_process')
 .spawn (
   process.execPath,
-  ['--experimental-vm-modules',
+  ['--experimental-import-meta-resolve',
+   '--experimental-vm-modules',
    ...(flags ? args[idx + 1].split (/\s+/) : []),
    '--',
    path.resolve (__dirname, '..', 'lib', 'command.js'),

--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -10,6 +10,7 @@
 
 import fs from 'node:fs/promises';
 import {dirname, resolve} from 'node:path';
+import url from 'node:url';
 import vm from 'node:vm';
 
 import * as acorn from 'acorn';
@@ -418,14 +419,16 @@ const run = queue =>
     return [{lines: {input: input.lines, output: output.lines}, comparison}];
   });
 
-const evaluateModule = async source => {
+const evaluateModule = moduleUrl => async source => {
   const queue = [];
   const enqueue = io => { queue.push (io); };
   const __doctest = {enqueue};
   const context = vm.createContext ({...global, __doctest});
   const module = new vm.SourceTextModule (source, {context});
   await module.link (async (specifier, referencingModule) => {
-    const entries = Object.entries (await import (specifier));
+    //  import.meta.resolve returned a promise prior to Node.js v20.0.0.
+    const importUrl = await import.meta.resolve (specifier, moduleUrl);
+    const entries = Object.entries (await import (importUrl));
     const module = new vm.SyntheticModule (
       entries.map (([name]) => name),
       () => {
@@ -496,18 +499,18 @@ const test = options => path => rewrite => async evaluate => {
 };
 
 export default options => async path => {
+  const __filename = resolve (process.cwd (), path);
   let context = {};
   switch (options.module) {
     case 'esm': {
       return test (options)
                   (path)
                   (rewriteJs ('module'))
-                  (evaluateModule);
+                  (evaluateModule (url.pathToFileURL (__filename)));
     }
     case 'commonjs': {
       const exports = {};
       const module = {exports};
-      const __filename = resolve (process.cwd (), path);
       const __dirname = dirname (__filename);
       context = {process, exports, module, require, __dirname, __filename};
     } // fall through

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git://github.com/davidchambers/doctest.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=16.2.0"
   },
   "dependencies": {
     "acorn": "8.11.x",


### PR DESCRIPTION
This pull request fixes our handling of import declarations.

Currently only absolute specifiers such as `import util from 'node:util'` are interpreted correctly:

  - `import foo from './foo.js'` attempts to import `[[doctest]]/lib/foo.js`; and
  - `import bar from 'bar'` attempts to load the main entry point of `[[doctest]]/node_modules/bar`.

This bug does not just affect import declarations *within* doctests: top-level import declarations are also affected.

The fix involves using [`import.meta.resolve`][1] to resolve the module specifier. We provide an argument for the non-standard [`parent`][2] parameter Node.js supports when the `--experimental-import-meta-resolve` flag is specified. This makes module resolution relative to the module in which the import declaration appears, as expected.

The `parent` parameter is available in Node.js v16.0.0, the oldest version we currently support, but needs a string argument. Node.js v16.2.0 added support for providing a `URL` object instead. As this is more convenient, and since we already have a breaking change on `main` (#176), I decided to increase our Node.js version requirement.


[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve
[2]: https://nodejs.org/docs/latest/api/esm.html#importmetaresolvespecifier
