### PR TITLE
remove `indentN`

### DIFF
--- a/lib/doctest.js
+++ b/lib/doctest.js
@@ -24,24 +24,21 @@ import {Line} from './Line.js';
 import require from './require.js';
 
 
-//    indentN :: Integer -> String -> String
-const indentN = n => s => s.replace (/^(?!$)/gm, ' '.repeat (n));
-
-//    formatLines :: Integer -> NonEmpty (Array Line) -> String
+//    formatLines :: String -> NonEmpty (Array Line) -> String
 const formatLines = indent => lines => (
   lines
   .map (line => `{number: ${show (line.number)}, text: ${show (line.text)}},`)
-  .join ('\n' + ' '.repeat (indent))
+  .join (`\n${indent}`)
 );
 
-//    formatInput :: Integer -> NonEmpty (Array Line) -> String
+//    formatInput :: String -> NonEmpty (Array Line) -> String
 const formatInput = indent => lines => (
   lines
   .map (line => line.text.replace (/^\s*([>]|[.]+)[ ]?/, ''))
-  .join ('\n' + ' '.repeat (indent))
+  .join (`\n${indent}`)
 );
 
-//    formatOutput :: Integer -> NonEmpty (Array Line) -> String
+//    formatOutput :: String -> NonEmpty (Array Line) -> String
 const formatOutput = indent => lines => {
   const [head, ...tail] = lines.map (line => line.text.replace (/^\s*/, ''));
   const match = /^![ ]?([^:]*)(?::[ ]?(.*))?$/.exec (head);
@@ -50,11 +47,11 @@ const formatOutput = indent => lines => {
     `  ${match == null ? head : `new ${match[1]}(${show (match[2] ?? '')})`}`,
     ...(tail.map (text => '  ' + text.replace (/^[.]+[ ]?/, ''))),
     ')',
-  ].join ('\n' + ' '.repeat (indent));
+  ].join (`\n${indent}`);
 };
 
-const wrapJs = sourceType => test => {
-  const source = formatInput (0) (test.input.lines);
+const wrapJs = sourceType => ({input, output}) => {
+  const source = formatInput ('') (input.lines);
   const ast = acorn.parse (
     source.startsWith ('{') && source.endsWith ('}') ? `(${source})` : source,
     {ecmaVersion: 2023, sourceType}
@@ -66,43 +63,43 @@ const wrapJs = sourceType => test => {
 __doctest.enqueue({
   input: {
     lines: [
-      ${formatLines (6) (test.input.lines)}
+      ${formatLines ('      ') (input.lines)}
     ],
     thunk: () => {
       return (
-        ${formatInput (8) (test.input.lines)}
+        ${formatInput ('        ') (input.lines)}
       );
     },
   },
-  output: ${test.output && `{
+  output: ${output && `{
     lines: [
-      ${formatLines (6) (test.output.lines)}
+      ${formatLines ('      ') (output.lines)}
     ],
     thunk: () => {
-      ${formatOutput (6) (test.output.lines)};
+      ${formatOutput ('      ') (output.lines)};
     },
   }`},
 });
 `;
 };
 
-const wrapCoffee = test => `
-__doctest.enqueue {
-  input: {
-    lines: [
-      ${formatLines (6) (test.input.lines)}
-    ]
-    thunk: ->
-      ${formatInput (6) (test.input.lines)}
-  }
-  output: ${test.output && `{
-    lines: [
-      ${formatLines (6) (test.output.lines)}
-    ]
-    thunk: ->
-      ${formatOutput (6) (test.output.lines)}
-  }`}
-}
+const wrapCoffee = ({indent, input, output}) => `
+${indent}__doctest.enqueue {
+${indent}  input: {
+${indent}    lines: [
+${indent}      ${formatLines (`${indent}      `) (input.lines)}
+${indent}    ]
+${indent}    thunk: ->
+${indent}      ${formatInput (`${indent}      `) (input.lines)}
+${indent}  }
+${indent}  output: ${output && `{
+${indent}    lines: [
+${indent}      ${formatLines (`${indent}      `) (output.lines)}
+${indent}    ]
+${indent}    thunk: ->
+${indent}      ${formatOutput (`${indent}      `) (output.lines)}
+${indent}  }`}
+${indent}}
 `;
 
 //    contiguous :: Line -> NonEmpty (Array Line) -> Boolean
@@ -381,9 +378,7 @@ const rewriteCoffee = ({
       return accum;
     }, {state: openingDelimiter == null ? 'open' : 'closed', tests: []});
 
-    return result.tests.map (
-      test => indentN (test.indent.length) (wrapCoffee (test))
-    );
+    return result.tests.map (wrapCoffee);
   });
 
   return CoffeeScript.compile (


### PR DESCRIPTION
This pull request changes `wrapCoffee` to indent the generated code appropriately, obviating the need for `indentN`.
