### PR TITLE
sanctuary-scripts@7.0.x

### DIFF
--- a/.config
+++ b/.config
@@ -3,4 +3,5 @@ repo-name = doctest
 author-name = David Chambers <dc@davidchambers.me>
 source-files = bin/doctest lib/**/*.js
 readme-source-files =
+test-files = test/index.js
 version-tag-prefix =

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,14 +8,6 @@
   },
   "overrides": [
     {
-      "files": ["README.md"],
-      "globals": {"doctest": "readonly"},
-      "rules": {
-        "no-extra-semi": ["off"],
-        "no-unused-vars": ["error", {"varsIgnorePattern": "^(toFahrenheit)$"}]
-      }
-    },
-    {
       "files": ["bin/doctest"],
       "parserOptions": {"sourceType": "script"}
     },
@@ -27,8 +19,15 @@
       }
     },
     {
+      "files": ["test/**/*.js"],
+      "rules": {
+        "max-len": ["off"]
+      }
+    },
+    {
       "files": ["test/commonjs/**/index.js"],
-      "parserOptions": {"sourceType": "script"}
+      "parserOptions": {"sourceType": "script"},
+      "globals": {"__doctest": "readonly"}
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
     "sanctuary-type-classes": "13.0.x"
   },
   "devDependencies": {
-    "c8": "8.0.x",
-    "oletus": "4.0.x",
-    "sanctuary-scripts": "6.0.x"
+    "sanctuary-scripts": "7.0.x"
   },
   "scripts": {
     "doctest": "sanctuary-doctest",

--- a/scripts/test
+++ b/scripts/test
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-source "${BASH_SOURCE%/*}/../node_modules/sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/node_modules/sanctuary-scripts/functions"
+
+branches="$(get min-branch-coverage)"
 
 set +f ; shopt -s globstar nullglob
-files=($(get source-files))
+# shellcheck disable=SC2207
+source_files=($(get source-files))
+# shellcheck disable=SC2207
+test_files=($(get test-files))
 set -f ; shopt -u globstar nullglob
 
-node_modules/.bin/c8 \
-  --check-coverage \
-  --100 \
-  --reporter text \
-  --reporter html \
-  $(printf ' --include %s' "${files[@]}") \
-  node --experimental-vm-modules -- node_modules/.bin/oletus -- test/index.js
+args=(
+  --check-coverage
+  --branches    "$branches"
+  --functions   0
+  --lines       0
+  --statements  0
+)
+for name in "${source_files[@]}" ; do
+  args+=(--include "$name")
+done
+node_modules/.bin/c8 "${args[@]}" -- node --experimental-vm-modules -- node_modules/.bin/oletus -- "${test_files[@]}"


### PR DESCRIPTION
<https://github.com/sanctuary-js/sanctuary-scripts/releases/tag/v7.0.0>

Unfortunately we're not (yet) able to remove our custom `test` script as we need to specify `--experimental-vm-modules`.

The updated `test` script is a slightly modified version of the canonical one:

```
$ diff <(curl -Ls https://github.com/sanctuary-js/sanctuary-scripts/raw/v7.0.0/bin/test) scripts/test
4,6c4
< source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/functions"
< 
< run_custom_script test "$@"
---
> source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/node_modules/sanctuary-scripts/functions"
27c25
< node_modules/.bin/c8 "${args[@]}" -- node_modules/.bin/oletus -- "${test_files[@]}"
---
> node_modules/.bin/c8 "${args[@]}" -- node --experimental-vm-modules -- node_modules/.bin/oletus -- "${test_files[@]}"
```
