### PR TITLE
remove `--nodejs` option

### DIFF
--- a/bin/doctest
+++ b/bin/doctest
@@ -2,21 +2,26 @@
 
 'use strict';
 
-const path = require ('path');
+const {spawn} = require ('node:child_process');
+const path = require ('node:path');
+const process = require ('node:process');
 
-const args = process.argv.slice (2);
-const idx = args.indexOf ('--nodejs');
-const flags = idx >= 0 && idx < args.length - 1;
+const command = process.execPath;
 
-require ('child_process')
-.spawn (
-  process.execPath,
-  ['--experimental-import-meta-resolve',
-   '--experimental-vm-modules',
-   ...(flags ? args[idx + 1].split (/\s+/) : []),
-   '--',
-   path.resolve (__dirname, '..', 'lib', 'command.js'),
-   ...(flags ? [...(args.slice (0, idx)), ...(args.slice (idx + 2))] : args)],
-  {cwd: process.cwd (), env: process.env, stdio: [0, 1, 2]}
-)
+const args = [
+  ...process.execArgv,
+  '--experimental-import-meta-resolve',
+  '--experimental-vm-modules',
+  '--',
+  path.resolve (__dirname, '..', 'lib', 'command.js'),
+  ...(process.argv.slice (2)),
+];
+
+const options = {
+  cwd: process.cwd (),
+  env: process.env,
+  stdio: [0, 1, 2],
+};
+
+spawn (command, args, options)
 .on ('exit', process.exit);

--- a/lib/program.js
+++ b/lib/program.js
@@ -12,8 +12,6 @@ program
          'specify module system ("commonjs" or "esm")')
 .option ('    --coffee',
          'parse CoffeeScript files')
-.option ('    --nodejs <options>',
-         'pass options directly to the "node" binary')
 .option ('    --prefix <prefix>',
          'specify Transcribe-style prefix (e.g. ".")')
 .option ('    --opening-delimiter <delimiter>',


### PR DESCRIPTION
This pull request changes the way users can provide flags and options to `node`.

Before:

```command
$ doctest --nodejs '--experimental-shadow-realm --no-warnings' --module esm -- index.js
```

After:

```command
$ node --experimental-shadow-realm --no-warnings -- doctest --module esm -- index.js
```

`--nodejs` can be traced back to 2010, when @jashkenas added the option to CoffeeScript's command-line interface: <https://github.com/jashkenas/coffeescript/commit/bc4498e0181793c740907f11371b49545e6aa673>. This may have been the best option available at the time; 13 years later we can use [`process.execArgv`][1] to provide the same functionality without a special option.


[1]: https://nodejs.org/api/process.html#processexecargv
